### PR TITLE
Improve cli abstractions

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -10,24 +10,24 @@ open Auxiliary.Functions
 
 let env_path = Filename.dirname (Filename.dirname Sys.executable_name) ^ "/lib/ast_gen/";;
 
-let setup_output (output_path : string) : (string * string * string) = 
-  let code_dir = output_path  ^ "/code/" in 
-  let graph_dir = output_path ^ "/graph/" in 
+let setup_output (output_path : string) : (string * string * string) =
+  let code_dir = output_path  ^ "/code/" in
+  let graph_dir = output_path ^ "/graph/" in
   let run_dir   = output_path ^ "/run/" in
 
   File_system.clean_dir output_path;
   File_system.create_dir code_dir;
   File_system.create_dir graph_dir;
   File_system.create_dir run_dir;
-  
+
   code_dir, graph_dir, run_dir
 
-let setup_node (mode : string) : string = 
+let setup_node (mode : Mode.t) : string =
   (* !REFACTOR : inbed this functionality into the dune build and install process *)
-  let js_folder    = env_path ^ "js/" in 
-  let node_modules = js_folder ^ "node_modules" in 
-  let package_info = js_folder ^ "package.json" in 
-  let script       = js_folder ^ "generate_cg.js" in 
+  let js_folder    = env_path ^ "js/" in
+  let node_modules = js_folder ^ "node_modules" in
+  let package_info = js_folder ^ "package.json" in
+  let script       = js_folder ^ "generate_cg.js" in
 
   if not (Sys.file_exists script)
     then failwith "[ERROR] Dependency tree genetarion script not found";
@@ -38,63 +38,63 @@ let setup_node (mode : string) : string =
   if Mode.is_multi_file mode && not (Sys.file_exists node_modules)
     then (
       print_endline "installing js dependencies";
-      let result = Sys.command ("npm install --prefix " ^ js_folder) in 
+      let result = Sys.command ("npm install --prefix " ^ js_folder) in
       if result != 0 then failwith "[ERROR] Unable to install js depedencies";
       print_endline "DONE!");
 
   script
 
 
-let main (filename : string) (output_path : string) (config_path : string) (mode : string) (generate_mdg : bool) (no_dot : bool) (verbose : bool) : int =
-  
+let main (filename : string) (output_path : string) (config_path : string) (mode : Mode.t) (generate_mdg : bool) (no_dot : bool) (verbose : bool) : int =
+
   (* SETUP *)
   let script = setup_node mode in
-  let dep_tree = DependencyTree.generate script filename mode in  
-  let code_dir, graph_dir, _ = setup_output output_path in 
+  let dep_tree = DependencyTree.generate script filename mode in
+  let code_dir, graph_dir, _ = setup_output output_path in
 
   (* process dependencies first with the aid of the depedency tree *)
-  let summaries = Summaries.empty () in 
-  let module_graphs = ModuleGraphs.empty () in 
-  List.iter (fun file_path -> 
-    let dir = Filename.dirname file_path ^ "/" in 
-    let filename = File_system.file_name file_path in 
+  let summaries = Summaries.empty () in
+  let module_graphs = ModuleGraphs.empty () in
+  List.iter (fun file_path ->
+    let dir = Filename.dirname file_path ^ "/" in
+    let filename = File_system.file_name file_path in
 
     (* STEP 0 : Generate AST using Flow library *)
-    let ast = Js_parser.from_file file_path in 
+    let ast = Js_parser.from_file file_path in
 
     (* STEP 1 : Normalize AST *)
     let norm_program = Ast.Normalize.program ast file_path in
-    let norm_program = if file_path = dep_tree.main then Program.set_main norm_program else norm_program in 
+    let norm_program = if file_path = dep_tree.main then Program.set_main norm_program else norm_program in
     let js_program = Ast.Pp.Js.print norm_program in
     File_system.write_to_file (code_dir ^ filename) js_program;
 
     (* STEP 2 : Generate MDG for the normalized code *)
     if generate_mdg then (
       let graph, exportedObject, external_calls = Mdg.Analyse.program mode verbose config_path norm_program in
-    
+
       ExternalReferences.iter (fun locs info ->
         let l_call = LocationSet.min_elt locs in
-        
-        (* module information *) 
-        let module_name = dir ^ info._module in 
-        let moduleEO = Summaries.get_opt summaries module_name in 
+
+        (* module information *)
+        let module_name = dir ^ info._module in
+        let moduleEO = Summaries.get_opt summaries module_name in
         option_may (fun moduleEO ->
-          let moduleGraph = ModuleGraphs.get module_graphs module_name in 
-          
+          let moduleGraph = ModuleGraphs.get module_graphs module_name in
+
           (* exported function information *)
-          let func_loc = ExportedObject.get_value_location moduleEO info.properties in 
+          let func_loc = ExportedObject.get_value_location moduleEO info.properties in
           if not (Graph.has_external_function graph func_loc) then (
-            let func_graph = Graph.get_function moduleGraph func_loc in 
+            let func_graph = Graph.get_function moduleGraph func_loc in
             Graph.add_external_func graph func_graph l_call func_loc
           );
-          
+
           Graph.add_call_edge graph l_call func_loc;
         ) moduleEO;
 
       ) external_calls;
-      
+
       (* save current module info*)
-      let alter_name = String.sub file_path 0 (String.length file_path - 3) in 
+      let alter_name = String.sub file_path 0 (String.length file_path - 3) in
       ModuleGraphs.add module_graphs file_path graph;
       ModuleGraphs.add module_graphs alter_name graph;
       Summaries.add summaries file_path exportedObject;
@@ -105,9 +105,9 @@ let main (filename : string) (output_path : string) (config_path : string) (mode
 
   (* output *)
   if generate_mdg then (
-    let main = DependencyTree.get_main dep_tree in 
-    let graph = ModuleGraphs.get module_graphs main in 
-    if not no_dot then 
+    let main = DependencyTree.get_main dep_tree in
+    let graph = ModuleGraphs.get module_graphs main in
+    if not no_dot then
       Mdg.Pp.Dot.output graph_dir graph;
     Mdg.Pp.CSV.output graph_dir graph;
   );
@@ -118,18 +118,18 @@ let main (filename : string) (output_path : string) (config_path : string) (mode
 let input_file : string Term.t =
   let doc = "Path to JavaScript file (.js) or directory containing JavaScript files for analysis." in
   let docv = "FILE_OR_DIR" in
-  let is_dir_or_file (param : string) : string =  
-    if Sys.file_exists param 
-      then param
-      else failwith ("[ERROR] Invalid input file : " ^ param) 
-  in 
+  Arg.(required & pos 0 (some file) None & info [] ~doc ~docv)
 
-  Term.(const is_dir_or_file $  Arg.(required & pos 0 (some string) None & info [] ~doc ~docv))
-
-
-let mode : string Term.t =
+let mode : Mode.t Term.t =
+  let mode_enum =
+    Arg.enum
+      [ ("basic", Mode.Basic)
+      ; ("single_file", Mode.Single_file)
+      ; ("multi_file", Mode.Multi_file);
+      ]
+  in
   let doc = "Analysis mode.\n\t 1) basic: attacker controlls all parameters from all functions \n\t 2) single_file: the attacker controlls the functions that were exported by the input file \n\t 3) multi_file: the attacker controlls the functions that were exported in the \"main\" file" in
-  Term.(const Mode.is_valid $ Arg.(value & opt string Mode.default & info ["m"; "mode"] ~doc))
+  Arg.(value & opt mode_enum Mode.single_file & info ["m"; "mode"] ~doc)
 
 let mdg : bool Term.t =
   let doc = "Generates Multiversion Dependency Graph." in
@@ -141,12 +141,12 @@ let no_dot : bool Term.t =
 
 let output_path : string Term.t =
   let doc = "Path to store all output files." in
-  let default_path = "graphjs-results" in 
+  let default_path = "graphjs-results" in
   Arg.(value & opt string default_path & info ["o"; "output"] ~doc)
 
 let config_path : string Term.t =
   let doc = "Path to configuration file." in
-  let default_path = env_path ^ "config.json" in 
+  let default_path = env_path ^ "config.json" in
   Arg.(value & opt non_dir_file default_path & info ["c"; "config"] ~doc)
 
 let verbose : bool Term.t =

--- a/lib/auxiliary/mode.ml
+++ b/lib/auxiliary/mode.ml
@@ -1,14 +1,22 @@
-let basic : string = "basic"
-let single_file : string = "single_file"
-let multi_file : string = "multi_file"
-let default : string = single_file
+type t = Basic | Single_file | Multi_file
 
-let is_valid (mode : string) : string =  
-  if mode = basic || mode = single_file || mode = multi_file 
-    then mode
-    else failwith "[ERROR] Invalid mode. Try using: basic, single_file or multi_file"
+let basic = Basic
+let single_file = Single_file
+let multi_file = Multi_file
+let is_basic = function Basic -> true | _ -> false
+let is_single_file = function Single_file -> true | _ -> false
+let is_multi_file = function Multi_file -> true | _ -> false
 
+let of_string = function
+  | "basic" -> Ok Basic
+  | "single_file" -> Ok Single_file
+  | "multi_file" -> Ok Multi_file
+  | _ ->
+      Error "[ERROR] Invalid mode. Try using: basic, single_file or multi_file"
 
-let is_basic (mode : string) : bool = mode = basic
-let is_single_file (mode : string) : bool = mode = single_file
-let is_multi_file (mode : string) : bool = mode = multi_file
+let pp fmt = function
+  | Basic -> Format.pp_print_string fmt "basic"
+  | Single_file -> Format.pp_print_string fmt "single_file"
+  | Multi_file -> Format.pp_print_string fmt "multi_file"
+
+let to_string mode = Format.asprintf "%a" pp mode

--- a/lib/auxiliary/mode.mli
+++ b/lib/auxiliary/mode.mli
@@ -1,0 +1,19 @@
+type t = Basic | Single_file | Multi_file
+
+val basic : t
+
+val single_file : t
+
+val multi_file : t
+
+val is_basic : t -> bool
+
+val is_single_file : t -> bool
+
+val is_multi_file : t -> bool
+
+val of_string : string -> (t, string) result
+
+val to_string : t -> string
+
+val pp : Format.formatter -> t -> unit

--- a/lib/mdg/analyse.ml
+++ b/lib/mdg/analyse.ml
@@ -23,22 +23,22 @@ module GraphConstrunction (Auxiliary : AbstractAnalysis.T) = struct
   (* ------- I N I T I A L I Z E ------- *)
   let initialize_functions (state : State.t) (funcs_info : Functions.Info.t) : unit =
     let init_func_header (state : State.t) (func : Functions.Id.t) (info : Functions.Info.info) : unit =
-      let graph = state.graph in 
-      let alloc_fun      = Graph.alloc_function graph in 
-      let add_func_node  = Graph.add_func_node  graph in 
-      let add_param_node = Graph.add_param_node graph in 
-      let add_param_edge = Graph.add_param_edge graph in 
+      let graph = state.graph in
+      let alloc_fun      = Graph.alloc_function graph in
+      let add_func_node  = Graph.add_func_node  graph in
+      let add_param_node = Graph.add_param_node graph in
+      let add_param_edge = Graph.add_param_edge graph in
 
-      let l_f = alloc_fun func.uid in 
+      let l_f = alloc_fun func.uid in
       add_func_node l_f func info.params (Location.empty ());
-      Store.update' state.store func.name (LocationSet.singleton l_f); 
+      Store.update' state.store func.name (LocationSet.singleton l_f);
 
 
       (* add param nodes and edges *)
-      List.iteri (fun i param -> 
-        let l_p = Graph.alloc_param graph in 
+      List.iteri (fun i param ->
+        let l_p = Graph.alloc_param graph in
         add_param_node l_p param (Location.empty ());
-        if param = "this" 
+        if param = "this"
           then add_param_edge l_f l_p "this"
           else add_param_edge l_f l_p (Int.to_string (i - 1))
       ) ("this" :: info.params);
@@ -46,319 +46,319 @@ module GraphConstrunction (Auxiliary : AbstractAnalysis.T) = struct
 
     Functions.Info.iter (init_func_header state) funcs_info
 
-  let init (function_info : Functions.Info.t) : t = 
-    let state' = State.empty_state function_info in 
+  let init (function_info : Functions.Info.t) : t =
+    let state' = State.empty_state function_info in
     Graph.add_literal_node state'.graph;
     Graph.add_taint_source state'.graph;
     initialize_functions state' function_info;
-    
+
     { state = state';
       auxiliary = Auxiliary.init () }
 
 
   (* ------- C O R E   A N A L Y S I S -------*)
-  let rec analyse_sequence (state : State.t) (analysis : Auxiliary.t ref) = 
+  let rec analyse_sequence (state : State.t) (analysis : Auxiliary.t ref) =
     List.iter (analyse state analysis)
-  
-  and analyse (state : State.t) (analysis : Auxiliary.t ref) (statement : m Statement.t) : unit = 
+
+  and analyse (state : State.t) (analysis : Auxiliary.t ref) (statement : m Statement.t) : unit =
     match statement with
     (* -------- I F -------- *)
     | _, If {consequent; alternate; _} ->
-      let state' = State.copy state in 
+      let state' = State.copy state in
       analyse_sequence state analysis consequent;
       option_may (analyse_sequence state' analysis) alternate;
-      
+
       Graph.lub state.graph state'.graph;
       Store.lub state.store state'.store;
-    
+
     (* -------- S W I T C H --------*)
-    | _, Switch {cases; _} -> 
-      let bodies = List.map (fun (_, case) -> case.Statement.Switch.Case.consequent) cases in 
+    | _, Switch {cases; _} ->
+      let bodies = List.map (fun (_, case) -> case.Statement.Switch.Case.consequent) cases in
       List.iter ( fun body -> analyse_sequence state analysis body) bodies
 
     (* -------- W H I L E  /  F O R -------- *)
     | _, ForIn {body; _}
-    | _, ForOf {body; _} 
-    | _, While {body; _} -> 
+    | _, ForOf {body; _}
+    | _, While {body; _} ->
       let rec fixed_point_computation (state : State.t) : unit =
         State.setup ();
-        let store' = Store.copy state.store in 
-        
+        let store' = Store.copy state.store in
+
         analyse_sequence state analysis body;
         Store.lub state.store store';
         if not (Store.equal state.store store')
           then fixed_point_computation state
-      
-      in 
+
+      in
       fixed_point_computation state
 
     (* -------- T R Y  -  C A T C H -------- *)
     | _, Try {body; handler; finalizer} ->
       analyse_sequence state analysis body;
-      let handler_body = Option.map (fun (_, handler) -> handler.Statement.Try.Catch.body) handler in 
+      let handler_body = Option.map (fun (_, handler) -> handler.Statement.Try.Catch.body) handler in
       option_may (analyse_sequence state analysis) handler_body;
       option_may (analyse_sequence state analysis) finalizer
 
     (* -------- W I T H  /  L A B E L E D -------- *)
     | _, Labeled {body; _}
-    | _, With    {body; _} -> 
+    | _, With    {body; _} ->
       analyse_sequence state analysis body
 
     | _ -> analyse_simple state analysis statement;
 
-  and analyse_simple (state : State.t) (analysis : Auxiliary.t ref) (statement : m Statement.t) : unit = 
-    let graph = state.graph in 
-    let store = state.store in 
+  and analyse_simple (state : State.t) (analysis : Auxiliary.t ref) (statement : m Statement.t) : unit =
+    let graph = state.graph in
+    let store = state.store in
     let contx = state.context in
-  
+
     (* aliases *)
-    let eval_expr = Store.eval_expr store state.this in 
-    let add_dep_edge = Graph.add_dep_edge graph in 
+    let eval_expr = Store.eval_expr store state.this in
+    let add_dep_edge = Graph.add_dep_edge graph in
     let add_arg_edge = Graph.add_arg_edge graph in
-    let add_call_edge = Graph.add_call_edge graph in 
-    let add_ref_call_edge = Graph.add_ref_call_edge graph in 
-    let add_ret_edge = Graph.add_ret_edge graph in 
-    let store_update = Store.update store in 
-    let alloc = Graph.alloc graph in 
-    let falloc = Graph.alloc_function graph in 
-    let add_node = Graph.add_obj_node graph in 
+    let add_call_edge = Graph.add_call_edge graph in
+    let add_ref_call_edge = Graph.add_ref_call_edge graph in
+    let add_ret_edge = Graph.add_ret_edge graph in
+    let store_update = Store.update store in
+    let alloc = Graph.alloc graph in
+    let falloc = Graph.alloc_function graph in
+    let add_node = Graph.add_obj_node graph in
     let add_cnode = Graph.add_call_node graph in
     let add_ret_node = Graph.add_return_node graph in
-    let add_property = Graph.staticAddProperty graph in 
+    let add_property = Graph.staticAddProperty graph in
     let add_property' = Graph.dynamicAddProperty graph in
-    let lookup = Graph.lookup graph in  
-    let new_version = Graph.staticNewVersion graph in 
-    let new_version' = Graph.dynamicNewVersion graph in 
+    let lookup = Graph.lookup graph in
+    let new_version = Graph.staticNewVersion graph in
+    let new_version' = Graph.dynamicNewVersion graph in
     let get_param_locs = Graph.get_param_locations graph in
-    let get_param_names = Functions.Context.get_param_names' contx in 
-    let get_func_id = Functions.Context.get_func_id contx in 
-    let is_last_definition = Functions.Context.is_last_definition contx in 
+    let get_param_names = Functions.Context.get_param_names' contx in
+    let get_func_id = Functions.Context.get_func_id contx in
+    let is_last_definition = Functions.Context.is_last_definition contx in
     let visit = Functions.Context.visit contx in
-    let get_curr_func = Functions.Context.get_current_function contx in 
-    
+    let get_curr_func = Functions.Context.get_current_function contx in
+
     (match statement with
       (* -------- A S S I G N - E X P R -------- *)
-      | _, AssignSimple {left; right} -> 
-        let _L = eval_expr right in 
+      | _, AssignSimple {left; right} ->
+        let _L = eval_expr right in
         store_update left _L
-  
+
       | _, AssignFunction {left; id; body; _} ->
-  
-        let func_id : Functions.Id.t = {uid = id; name = Identifier.get_name left} in 
-        (* functions with the same name can be nested inside the same context 
+
+        let func_id : Functions.Id.t = {uid = id; name = Identifier.get_name left} in
+        (* functions with the same name can be nested inside the same context
             (only consider the last definition with such name) *)
         if is_last_definition func_id then (
           (* add function definition dependency *)
-          let f_i = falloc id in 
+          let f_i = falloc id in
           store_update left (LocationSet.singleton f_i);
 
-          
+
           (* setup new store with only the param and corresponding locations *)
-          let param_locs = get_param_locs func_id in 
+          let param_locs = get_param_locs func_id in
           let new_state = {state with store = Store.merge store param_locs; context = visit func_id} in
           analyse_sequence new_state analysis body
         );
-        
-  
+
+
       (* -------- A S S I G N - O P -------- *)
-      | loc, AssignBinary {left; opLeft; opRght; id; _} -> 
-        let _L1, _L2 = eval_expr opLeft, eval_expr opRght in 
-        let l_i = alloc id in 
+      | loc, AssignBinary {left; opLeft; opRght; id; _} ->
+        let _L1, _L2 = eval_expr opLeft, eval_expr opRght in
+        let l_i = alloc id in
         LocationSet.apply (flip add_dep_edge l_i) (LocationSet.union _L1 _L2);
         store_update left (LocationSet.singleton l_i);
-        
+
         (* ! add node info*)
         add_node l_i (Identifier.get_name left) loc
-      
-      | loc, AssignUnary {left; argument; id; _} -> 
-        let _L1 = eval_expr argument in 
-        let l_i = alloc id in 
+
+      | loc, AssignUnary {left; argument; id; _} ->
+        let _L1 = eval_expr argument in
+        let l_i = alloc id in
         LocationSet.apply (flip add_dep_edge l_i) _L1;
         store_update left (LocationSet.singleton l_i);
-        
+
         (* ! add node info*)
         add_node l_i (Identifier.get_name left) loc
-  
-  
+
+
       (* -------- N E W   O B J E C T -------- *)
-      | loc, AssignArray {id; left} 
-      | loc, AssignObject {id; left} -> 
+      | loc, AssignArray {id; left}
+      | loc, AssignObject {id; left} ->
         let l_i = alloc id in
         store_update left (LocationSet.singleton l_i);
         add_node l_i (Identifier.get_name left) loc;
-      
-  
+
+
       (* -------- S T A T I C   P R O P E R T Y   L O O K U P -------- *)
-      | loc, StaticLookup {left; _object; property; id; _} -> 
-        let add_node' : location -> unit = fun abs_loc -> add_node abs_loc (property_lookup_name left _object property) loc in 
-        
-        let _L = eval_expr _object in 
+      | loc, StaticLookup {left; _object; property; id; _} ->
+        let add_node' : location -> unit = fun abs_loc -> add_node abs_loc (property_lookup_name left _object property) loc in
+
+        let _L = eval_expr _object in
         add_property _L property id add_node';
-        let _L' = LocationSet.map_flat (flip lookup property) _L in 
+        let _L' = LocationSet.map_flat (flip lookup property) _L in
         store_update left _L';
-  
+
       (* -------- D Y N A M I C   P R O P E R T Y   L O O K U P -------- *)
       | loc, DynmicLookup {left; _object; property; id} ->
-        let add_node' : location -> unit = fun abs_loc -> add_node abs_loc (property_lookup_name left _object "*") loc in 
-  
-        let _L1, _L2 = eval_expr _object, eval_expr property in 
+        let add_node' : location -> unit = fun abs_loc -> add_node abs_loc (property_lookup_name left _object "*") loc in
+
+        let _L1, _L2 = eval_expr _object, eval_expr property in
         add_property' _L1 _L2 id add_node';
-        let _L' = LocationSet.map_flat (flip lookup "*") _L1 in 
+        let _L' = LocationSet.map_flat (flip lookup "*") _L1 in
         store_update left _L'
-  
+
       (* -------- S T A T I C   P R O P E R T Y   U P D A T E -------- *)
       | loc, StaticUpdate {_object; property; right; id; _} ->
-        let add_node' : location -> unit = fun abs_loc -> add_node abs_loc (Option.value (Expression.get_id_opt _object) ~default:"*") loc in 
-        
+        let add_node' : location -> unit = fun abs_loc -> add_node abs_loc (Option.value (Expression.get_id_opt _object) ~default:"*") loc in
+
         let _L1, _L2 = eval_expr _object, eval_expr right in
-        let _L1' = new_version store _L1 property id add_node' in 
+        let _L1' = new_version store _L1 property id add_node' in
         LocationSet.apply ( fun l_1 ->
           LocationSet.apply (fun l_2 ->
               Graph.add_prop_edge graph l_1 l_2 (Some property)
             ) _L2
         ) _L1';
-  
+
       (* -------- D Y N A M I C   P R O P E§ R T Y   U P D A T E -------- *)
-      | loc, DynmicUpdate {_object; property; right; id} -> 
-        let add_node' : location -> unit = fun abs_loc -> add_node abs_loc (Option.value (Expression.get_id_opt _object) ~default:"*") loc in 
-  
-        let _L1, _L2, _L3 = eval_expr _object, 
-                            eval_expr property, 
+      | loc, DynmicUpdate {_object; property; right; id} ->
+        let add_node' : location -> unit = fun abs_loc -> add_node abs_loc (Option.value (Expression.get_id_opt _object) ~default:"*") loc in
+
+        let _L1, _L2, _L3 = eval_expr _object,
+                            eval_expr property,
                             eval_expr right in
-  
-        let _L1' = new_version' store _L1 _L2 id add_node' in 
+
+        let _L1' = new_version' store _L1 _L2 id add_node' in
         LocationSet.apply ( fun l_1 ->
           LocationSet.apply (fun l_3 ->
               Graph.add_prop_edge graph l_1 l_3 None
             ) _L3
         ) _L1';
-  
-  
+
+
       (* -------- C A L L -------- *)
       | loc, AssignNewCall {left; callee; arguments; id_call; id_retn; _}
-      | loc, AssignFunCall {left; callee; arguments; id_call; id_retn; _} -> 
-        let _Lss = List.map eval_expr arguments in 
-        let l_call = alloc id_call in 
-        let l_retn = alloc id_retn in 
-  
+      | loc, AssignFunCall {left; callee; arguments; id_call; id_retn; _} ->
+        let _Lss = List.map eval_expr arguments in
+        let l_call = alloc id_call in
+        let l_retn = alloc id_retn in
+
         (* get function definition information *)
-        let f    = Identifier.get_name callee in 
+        let f    = Identifier.get_name callee in
         let f_id = get_func_id f in
-  
+
         (* node information *)
         add_cnode l_call f loc;
         add_node l_retn (Identifier.get_name left) loc;
-        
+
         (* argument edges *)
-        let params = map_default get_param_names [] f_id in 
-        List.iteri ( fun i _Ls -> 
-          let param_name = Option.value (List.nth_opt params i) ~default:"undefined" in 
+        let params = map_default get_param_names [] f_id in
+        List.iteri ( fun i _Ls ->
+          let param_name = Option.value (List.nth_opt params i) ~default:"undefined" in
           LocationSet.apply (fun l -> add_arg_edge l l_call (string_of_int i) param_name) _Ls
         ) _Lss;
-  
+
         (* ! add ref call edge (shotcut) from function definition to this call *)
         let f_orig = get_curr_func () in
         option_may (fun id ->
-          let l_f = Graph.get_func_node graph id in 
+          let l_f = Graph.get_func_node graph id in
           add_ref_call_edge (Option.get l_f) l_call;
           ()
         ) f_orig;
-  
+
         (* return edge *)
         add_ret_edge l_call l_retn;
         store_update left (LocationSet.singleton l_retn);
-  
+
         (* call edge to function definition (if defined) *)
         option_may (fun id ->
-          let l_f = Graph.get_func_node graph id in 
+          let l_f = Graph.get_func_node graph id in
           add_call_edge l_call (Option.get l_f)
         ) f_id;
-      
-      | loc, AssignMetCallStatic {left; _object; property; arguments; id_call; id_retn; _} -> 
+
+      | loc, AssignMetCallStatic {left; _object; property; arguments; id_call; id_retn; _} ->
         analyse_method_call state loc left _object property arguments id_call id_retn;
-      
-      | loc, AssignMetCallDynmic {left; _object; arguments; id_call; id_retn; _} -> 
+
+      | loc, AssignMetCallDynmic {left; _object; arguments; id_call; id_retn; _} ->
         analyse_method_call state loc left _object "*" arguments id_call id_retn;
-  
+
       (* -------- R E T U R N -------- *)
-      | loc, Return {id; argument} -> 
-        let _L = Option.map eval_expr argument in 
-        let l_retn = alloc id in 
-  
+      | loc, Return {id; argument} ->
+        let _L = Option.map eval_expr argument in
+        let l_retn = alloc id in
+
         if (Option.is_some _L) then (
           let _L = Option.get _L in
           LocationSet.apply (flip add_dep_edge l_retn) _L
         );
-  
+
         add_ret_node l_retn loc;
-  
-      | _, AssignYield _ 
+
+      | _, AssignYield _
 
       (* -------- O T H E R   C O N S T R U C T S -------- *)
       | _, ExportDefaultDecl _
       | _, ExportNamedDecl   _
-      | _, ImportDecl        _ 
+      | _, ImportDecl        _
 
       | _, VarDecl  _
-      | _, Throw    _ 
-      | _, Break    _ 
-      | _, Continue _ 
+      | _, Throw    _
+      | _, Break    _
+      | _, Continue _
       | _, Debugger _ -> ()
-          
+
       | _ -> failwith "[ERROR] Statement node analysis not defined");
 
     analysis := Auxiliary.analyse !analysis state statement;
 
-  
+
   and property_lookup_name (left : m Identifier.t) (_object : m Expression.t) (property : string) : string =
-    let obj_name = Option.value (Expression.get_id_opt _object) ~default:"*" in 
-    let obj_prop = obj_name ^ "." ^ property in 
+    let obj_name = Option.value (Expression.get_id_opt _object) ~default:"*" in
+    let obj_prop = obj_name ^ "." ^ property in
     if Identifier.is_generated left then obj_prop else Identifier.get_name left ^ ", " ^ obj_prop
 
   and analyse_method_call (state : State.t) (loc : Location.t) (left : m Identifier.t) (_object : m Expression.t) (property : property) (arguments : m Expression.t list) (id_call : int) (id_retn : int) : unit =
     (* aliases *)
-    let graph = state.graph in 
-    let eval_expr = Store.eval_expr state.store state.this in 
-    let store_update = Store.update state.store in 
-    let alloc = Graph.alloc graph in 
+    let graph = state.graph in
+    let eval_expr = Store.eval_expr state.store state.this in
+    let store_update = Store.update state.store in
+    let alloc = Graph.alloc graph in
     let add_node = Graph.add_obj_node graph in
     let add_cnode = Graph.add_call_node graph in
-    let add_ret_edge = Graph.add_ret_edge graph in 
+    let add_ret_edge = Graph.add_ret_edge graph in
     let add_arg_edge = Graph.add_arg_edge graph in
-    let add_call_edge = Graph.add_call_edge graph in 
-    let add_ref_call_edge = Graph.add_ref_call_edge graph in 
-    let get_curr_func = Functions.Context.get_current_function state.context in  
-    let lookup = Graph.lookup graph in  
+    let add_call_edge = Graph.add_call_edge graph in
+    let add_ref_call_edge = Graph.add_ref_call_edge graph in
+    let get_curr_func = Functions.Context.get_current_function state.context in
+    let lookup = Graph.lookup graph in
 
-  
-    let _Lss = List.map eval_expr arguments in 
-        
+
+    let _Lss = List.map eval_expr arguments in
+
     let _Lthis = eval_expr _object in
-    let l_call = alloc id_call in 
-    let l_retn = alloc id_retn in 
-    
+    let l_call = alloc id_call in
+    let l_retn = alloc id_retn in
+
     (* get function definition information *)
-    let obj_name = Option.value (Expression.get_id_opt _object) ~default:"*" in 
-    let f        = obj_name ^ "." ^ property in 
-  
+    let obj_name = Option.value (Expression.get_id_opt _object) ~default:"*" in
+    let f        = obj_name ^ "." ^ property in
+
     (* node information *)
     add_cnode l_call f loc;
     add_node l_retn (Identifier.get_name left) loc;
-  
+
     (* ! graphjs only adds edge for this property *)
     LocationSet.apply (fun l_this -> add_arg_edge  l_this l_call "this" "this") _Lthis;
 
     (* lookup function header node associated with the property *)
-    let found_func = ref false in 
+    let found_func = ref false in
     if property != "*" then (
-      let _Lfunc = LocationSet.map_flat (flip lookup property) _Lthis in 
+      let _Lfunc = LocationSet.map_flat (flip lookup property) _Lthis in
       if LocationSet.cardinal _Lfunc = 1 then (
-        let l_func = LocationSet.min_elt _Lfunc in 
-        let func_node = Graph.find_node_opt graph l_func in 
-        match func_node with 
+        let l_func = LocationSet.min_elt _Lfunc in
+        let func_node = Graph.find_node_opt graph l_func in
+        match func_node with
           | Some {_type = Function (_, params); _} -> ();
-            List.iteri ( fun i _Ls -> 
-              let param_name = Option.value (List.nth_opt params i) ~default:"undefined" in 
+            List.iteri ( fun i _Ls ->
+              let param_name = Option.value (List.nth_opt params i) ~default:"undefined" in
               LocationSet.apply (fun l -> add_arg_edge l l_call (string_of_int i) param_name) _Ls
             ) _Lss;
             add_call_edge l_call l_func;
@@ -366,18 +366,18 @@ module GraphConstrunction (Auxiliary : AbstractAnalysis.T) = struct
           | _ -> ();
       );
     );
-    
+
     if not !found_func then (
-      List.iteri ( fun i _Ls -> 
+      List.iteri ( fun i _Ls ->
         LocationSet.apply (fun l -> add_arg_edge l l_call (string_of_int i) "undefined") _Ls
       ) _Lss
     );
-  
-    (* ! add ref call edge (shotcut) from function definition to this call 
+
+    (* ! add ref call edge (shotcut) from function definition to this call
        ! did this to be comaptible with graphjs queries *)
     let f_orig = get_curr_func () in
-    option_may (fun id -> 
-      let l_f = Graph.get_func_node state.graph id in 
+    option_may (fun id ->
+      let l_f = Graph.get_func_node state.graph id in
       add_ref_call_edge (Option.get l_f) l_call;
       ()
     ) f_orig;
@@ -388,20 +388,20 @@ module GraphConstrunction (Auxiliary : AbstractAnalysis.T) = struct
     store_update left (LocationSet.singleton l_retn)
 
   let run (init : t) (statements : m Statement.t list) : State.t * Auxiliary.t =
-    let auxiliary = ref init.auxiliary in 
-    let state = init.state in 
+    let auxiliary = ref init.auxiliary in
+    let state = init.state in
 
     analyse_sequence state auxiliary statements;
     state, !auxiliary
-    
+
 end
 
-let rec add_taint_sinks (state : State.t) (config : Config.t) (ext_calls : ExternalReferences.t) : unit = 
-  let graph = state.graph in 
+let rec add_taint_sinks (state : State.t) (config : Config.t) (ext_calls : ExternalReferences.t) : unit =
+  let graph = state.graph in
 
-  Graph.iter_nodes (fun loc node -> 
-    match node._type with 
-      | Call callee -> 
+  Graph.iter_nodes (fun loc node ->
+    match node._type with
+      | Call callee ->
         (* function sink *)
         let sink_info = Config.get_function_sink_info config callee in
         option_may (fun (sink_info : functionSink) ->
@@ -409,14 +409,14 @@ let rec add_taint_sinks (state : State.t) (config : Config.t) (ext_calls : Exter
         ) sink_info;
 
         (* package sink *)
-        let referece_info = ExternalReferences.get_opt ext_calls loc in 
+        let referece_info = ExternalReferences.get_opt ext_calls loc in
         option_may (fun ref ->
           (* check if there is only one property *)
           if List.length ref.properties = 1 then
-            let method_name = List.nth ref.properties 0 in 
-            let package_name = ref._module in 
-            let sink_info = Config.get_package_sink_info config package_name method_name in 
-            option_may (fun (sink_info : package) -> 
+            let method_name = List.nth ref.properties 0 in
+            let package_name = ref._module in
+            let sink_info = Config.get_package_sink_info config package_name method_name in
+            option_may (fun (sink_info : package) ->
               add_taink_sink graph loc node method_name sink_info.args
             ) sink_info
         ) referece_info
@@ -424,9 +424,9 @@ let rec add_taint_sinks (state : State.t) (config : Config.t) (ext_calls : Exter
       | _ -> ()
   ) graph
 
-and add_taink_sink (graph : Graph.t) (loc : location) (node : Graph.Node.t) (sink_name : string) (sink_args : int list) : unit = 
+and add_taink_sink (graph : Graph.t) (loc : location) (node : Graph.Node.t) (sink_name : string) (sink_args : int list) : unit =
   let salloc = Graph.alloc_tsink graph in
-  let add_tsink = Graph.add_taint_sink graph in 
+  let add_tsink = Graph.add_taint_sink graph in
   let add_sink_edge = Graph.add_sink_edge graph in
   let add_dep_edge = Graph.add_dep_edge graph in
 
@@ -436,51 +436,51 @@ and add_taink_sink (graph : Graph.t) (loc : location) (node : Graph.Node.t) (sin
   add_sink_edge loc l_tsink sink_name;
 
   (* add depedency edges from dangerous inputs (arguments) to taint sink *)
-  let args = Graph.get_arg_locations graph loc in 
+  let args = Graph.get_arg_locations graph loc in
   List.iter (fun dangerous_index ->
     let dangerous_index = string_of_int (dangerous_index - 1) in
-    let arg_locs = List.filter (((=) dangerous_index) << fst) args in 
+    let arg_locs = List.filter (((=) dangerous_index) << fst) args in
     List.iter (fun (_, l) -> add_dep_edge l l_tsink) arg_locs
   ) sink_args
 
 
-let add_taint_sources (state : State.t) (_config : Config.t) (mode : string) (is_main : bool) (exportsObject : ExportedObject.t): unit = 
-  let graph = state.graph in 
-  let l_tsource = loc_taint_source in 
+let add_taint_sources (state : State.t) (_config : Config.t) (mode : Mode.t) (is_main : bool) (exportsObject : ExportedObject.t): unit =
+  let graph = state.graph in
+  let l_tsource = loc_taint_source in
   let add_taint_edge = Graph.add_taint_edge graph in
-  
-  (* BASIC ATTACKER MODEL : 
+
+  (* BASIC ATTACKER MODEL :
     -> the attacker controlls all function parameters
   .*)
   if Mode.is_basic mode then (
     Graph.iter_nodes (fun location node ->
       match node._type with
-        | Function _ -> 
-          let edges = Graph.get_edges graph location in 
-          EdgeSet.iter (fun (edge : Edge.t) -> 
+        | Function _ ->
+          let edges = Graph.get_edges graph location in
+          EdgeSet.iter (fun (edge : Edge.t) ->
             match edge._type with
               | Edge.Parameter _ -> add_taint_edge l_tsource edge._to
               | _ -> ()
           ) edges
 
         | _ -> ()
-    ) graph 
+    ) graph
 
 
-  (* SINGLE-FILE ATTACKER MODEL 
+  (* SINGLE-FILE ATTACKER MODEL
     -> the attacker controlls all exported functions of the input file
 
     MULTI-FILE ATTACKER MODEL
     ->  the attacker controlls all exported functions of the main file
   .*)
   ) else if Mode.is_single_file mode || (Mode.is_multi_file mode && is_main) then (
-    let exported_funcs = ExportedObject.get_all_values exportsObject in 
+    let exported_funcs = ExportedObject.get_all_values exportsObject in
     List.iter (fun l_func ->
-      let func_node = Graph.find_node graph l_func in 
-      match func_node._type with 
-        | Function _ -> 
-          let edges = Graph.get_edges graph l_func in 
-          EdgeSet.iter (fun (edge : Edge.t) -> 
+      let func_node = Graph.find_node graph l_func in
+      match func_node._type with
+        | Function _ ->
+          let edges = Graph.get_edges graph l_func in
+          EdgeSet.iter (fun (edge : Edge.t) ->
             match edge._type with
               | Edge.Parameter _ -> add_taint_edge l_tsource edge._to
               | _ -> ()
@@ -494,73 +494,73 @@ let add_taint_sources (state : State.t) (_config : Config.t) (mode : string) (is
 
 
 
-let rec buildExportsObject (state : State.t) (info : buildExportsObject) : ExportedObject.t = 
+let rec buildExportsObject (state : State.t) (info : buildExportsObject) : ExportedObject.t =
   (* module.exports is assigned to a variable *)
-  let exportsObject = ref (ExportedObject.create 10) in 
-  option_may (fun loc -> 
+  let exportsObject = ref (ExportedObject.create 10) in
+  option_may (fun loc ->
     exportsObject := construct_object state loc;
   ) info.moduleExportsObject;
 
   (* assignments to the properties of module.exports *)
   HashTable.iter (fun property loc ->
-    let object' = construct_object state loc in 
+    let object' = construct_object state loc in
     exportsObject := ExportedObject.add_property !exportsObject property object';
   ) info.moduleExportsAssigns;
 
   (* assignments to the properties of exports *)
   HashTable.iter (fun property loc ->
-    let object' = construct_object state loc in 
+    let object' = construct_object state loc in
     exportsObject := ExportedObject.add_property !exportsObject property object';
   ) info.exportsAssigns;
 
   !exportsObject;
 
-and construct_object (state : State.t) (loc : LocationSet.t) : ExportedObject.t = 
-  let graph = state.graph in 
-  if LocationSet.cardinal loc = 1 then 
-    let loc = LocationSet.min_elt loc in 
-    let node = Graph.find_node state.graph loc in  
-    match node._type with 
-      | Object _ -> 
-        let object' = ref (ExportedObject.create 10) in  
-        let all_properties = Graph.get_static_properties graph loc in 
-        List.iter (fun property -> 
-          let _L = Graph.lookup graph loc property in 
-          let object'' = construct_object state _L in 
+and construct_object (state : State.t) (loc : LocationSet.t) : ExportedObject.t =
+  let graph = state.graph in
+  if LocationSet.cardinal loc = 1 then
+    let loc = LocationSet.min_elt loc in
+    let node = Graph.find_node state.graph loc in
+    match node._type with
+      | Object _ ->
+        let object' = ref (ExportedObject.create 10) in
+        let all_properties = Graph.get_static_properties graph loc in
+        List.iter (fun property ->
+          let _L = Graph.lookup graph loc property in
+          let object'' = construct_object state _L in
           object' := ExportedObject.add_property !object' property object''
         ) all_properties;
-        
+
         (* return *)
         !object'
 
       | Function _ -> ExportedObject.Value loc
       | _ -> ExportedObject.empty ()
-    
-  else if LocationSet.is_empty loc then 
+
+  else if LocationSet.is_empty loc then
     ExportedObject.empty ()
 
   else failwith "[ERROR] exported object has a property with multiple locations"
-  
+
 ;;
 
 
 
-let rec program (mode : string) (is_verbose : bool) (config_path : string) (program : m Program.t) : Graph.t * ExportedObject.t * ExternalReferences.t = 
+let rec program (mode : Mode.t) (is_verbose : bool) (config_path : string) (program : m Program.t) : Graph.t * ExportedObject.t * ExternalReferences.t =
   verbose := is_verbose;
 
-  let module Analysis = AbstractAnalysis.Combine 
-    (BuildExportsObject.Analysis) 
-    (AbstractAnalysis.Combine 
-      (CollectExternalCalls.Analysis) 
+  let module Analysis = AbstractAnalysis.Combine
+    (BuildExportsObject.Analysis)
+    (AbstractAnalysis.Combine
+      (CollectExternalCalls.Analysis)
       (SinkAliases.Analysis (struct let filename = config_path end)) )
-  in 
-  let module BuildMDG = GraphConstrunction (Analysis) in 
+  in
+  let module BuildMDG = GraphConstrunction (Analysis) in
 
-  let init_state      = BuildMDG.init (Program.get_functions program) in 
+  let init_state      = BuildMDG.init (Program.get_functions program) in
   let state, analysis = BuildMDG.run init_state (Program.get_body program) in
 
   (* process auxiliary analysis outputs*)
-  let exportsObjectInfo, config, external_calls = get_analysis_output (Analysis.finish analysis) in 
+  let exportsObjectInfo, config, external_calls = get_analysis_output (Analysis.finish analysis) in
 
   let exportsObject = buildExportsObject state exportsObjectInfo in
   add_taint_sinks state config external_calls;
@@ -568,10 +568,10 @@ let rec program (mode : string) (is_verbose : bool) (config_path : string) (prog
 
   state.graph, exportsObject, external_calls;
 
-and get_analysis_output (result : AnalysisType.t) : buildExportsObject * sinkAliases * collectExternalCalls = 
-  match result with 
-    | Combined 
-        (BuildExportsObject exportsObject, 
-         Combined (CollectExternalCalls ext_calls, 
+and get_analysis_output (result : AnalysisType.t) : buildExportsObject * sinkAliases * collectExternalCalls =
+  match result with
+    | Combined
+        (BuildExportsObject exportsObject,
+         Combined (CollectExternalCalls ext_calls,
                    SinkAliases config             )) -> exportsObject, config, ext_calls
     | _ -> failwith "[ERROR] Unable to extract analysis output"

--- a/lib/setup/dependencyTree.ml
+++ b/lib/setup/dependencyTree.ml
@@ -5,72 +5,74 @@ type t = {
   structure : Yojson.Basic.t;
 }
 
-let generate_dt (script : string ) (filename : string) : string = 
+let generate_dt (script : string ) (filename : string) : string =
   "node " ^ script ^ " " ^ filename
 
-let single_file_dt (filename : string) : string = 
+let single_file_dt (filename : string) : string =
   "{ \"" ^ filename ^ "\" : {} }"
 
-let rec generate (script : string) (filename : string) (mode : string) : t =
+let rec generate (script : string) (filename : string) (mode : Mode.t) : t =
   let main_file = get_main_file filename mode in
-  let output = if Mode.is_multi_file mode 
-    then File_system.run_command (generate_dt script main_file) 
+  let output = if Mode.is_multi_file mode
+    then File_system.run_command (generate_dt script main_file)
     else single_file_dt main_file
   in
 
   { main      = main_file;
     structure = Yojson.Basic.from_string output }
-    
-and get_main_file (filename : string) (mode : string) : string =
-  let filename = File_system.real_path filename in 
-  match mode with 
+
+and get_main_file (filename : string) (mode : Mode.t) : string =
+  let filename = File_system.real_path filename in
+  match mode with
     (* in single file analysis, the filename should already be the main file*)
-    | mode when Mode.is_basic mode || Mode.is_single_file mode -> 
-      if not (Sys.is_directory filename) 
-        then filename 
-        else failwith "[ERROR] A folder was provided for single file analysis" 
-    
-    (* in multifile analysis, the filename can be the main file or a module 
+    | mode when Mode.is_basic mode || Mode.is_single_file mode ->
+      if not (Sys.is_directory filename)
+        then filename
+        else failwith "[ERROR] A folder was provided for single file analysis"
+
+    (* in multifile analysis, the filename can be the main file or a module
        directory if it is a directory we need to find the main file of the module *)
-    | mode when Mode.is_multi_file mode -> 
-      if not (Sys.is_directory filename) 
+    | mode when Mode.is_multi_file mode ->
+      if not (Sys.is_directory filename)
         then filename
         else find_module_main filename
-    | _ -> failwith "[ERROR] No implementation for mode " ^ mode
+    | _ ->
+      Format.kasprintf failwith "[ERROR] No implementation for mode %a" Mode.pp
+        mode
 
-and find_module_main (module_path : string) : string = 
+and find_module_main (module_path : string) : string =
   (* https://docs.npmjs.com/cli/v10/configuring-npm/package-json#main *)
-  let main_file : (string option) ref  = ref None in 
-  let module_path = ref module_path in 
-  
+  let main_file : (string option) ref  = ref None in
+  let module_path = ref module_path in
+
   (* check package.json *)
-  let package_path = Filename.concat !module_path "package.json" in 
+  let package_path = Filename.concat !module_path "package.json" in
   if Sys.file_exists package_path then (
     let package_info = Yojson.Basic.from_file package_path in
     match Yojson.Basic.Util.member "main" package_info with
-      | `String main -> 
-        let main_path = Filename.concat !module_path main in 
-        if not (Sys.file_exists main_path) 
+      | `String main ->
+        let main_path = Filename.concat !module_path main in
+        if not (Sys.file_exists main_path)
           then failwith "[ERROR] Main file described in package.json doesn't exist"
-        else if Sys.is_directory main_path 
+        else if Sys.is_directory main_path
           then module_path := main_path
           else main_file := Some main_path
 
-          
+
       | _ -> ()
   );
 
   (* check if index.js exists in the root folder *)
-  let index_path = Filename.concat !module_path "index.js" in 
+  let index_path = Filename.concat !module_path "index.js" in
   if Sys.file_exists index_path && Option.is_none !main_file then (
     main_file := Some index_path
   );
 
-  if Option.is_some !main_file 
+  if Option.is_some !main_file
     then Option.get !main_file
-    else failwith ("[ERROR] Unable to find main file of module : " ^ !module_path) 
+    else failwith ("[ERROR] Unable to find main file of module : " ^ !module_path)
 
-  
+
 
 let get_main (dep_tree : t) : string = dep_tree.main
 
@@ -86,6 +88,3 @@ let bottom_up_visit (dep_tree : t) : string list =
   let visit_order = visit dep_tree.structure []  in
   (* remove duplicated from visit *)
   List.rev (List.fold_left (fun final_order curr -> if List.mem curr final_order then final_order else curr :: final_order)  [] visit_order)
-
-
-  


### PR DESCRIPTION
Use `Cmdliner.Arg.file` conv to parse valid files. Cmdliners' file conv already does a `Sys.file_exists` so we avoid code duplication here.

Also define `Mode.t` as an algebraic datatype to reduce string allocations and allow for faster instant `is_` mode checks.

In a separate PR I'll try to fix CI as well.

PS: My editor removes trailing white space. So, sorry for the big diff! The only relevant changes are in `main.ml` in the bottom and `mode.ml`. 