### PR TITLE
Downgrade flow_parser to version 0.246.0

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -31,7 +31,7 @@
   dune
   dune-site
   (flow_parser
-   (>= 0.257.0))
+   (>= 0.246.0))
   (ocaml
    (>= "5.2.1"))
   ocamlformat

--- a/graphjs.opam
+++ b/graphjs.opam
@@ -23,7 +23,7 @@ depends: [
   "conf-npm"
   "dune" {>= "3.2"}
   "dune-site"
-  "flow_parser" {>= "0.257.0"}
+  "flow_parser" {>= "0.246.0"}
   "ocaml" {>= "5.2.1"}
   "ocamlformat"
   "ocamlgraph"


### PR DESCRIPTION
Currently theres no 0.257.0 in the opam repository, so we downgrade to the latest available version in the opam repository.


EDIT: Or do we want to get the latest version from https://github.com/facebook/flow? I can pin it if we want to