### PR TITLE
Implement export views in the MDG exporter 

### DIFF
--- a/src/base/dune
+++ b/src/base/dune
@@ -19,4 +19,4 @@
   log
   json
   time)
- (libraries unix fpath yojson))
+ (libraries unix str fpath yojson))

--- a/src/client/cmd_mdg.ml
+++ b/src/client/cmd_mdg.ml
@@ -11,6 +11,7 @@ module Options = struct
     ; unsafe_literal_properties : bool
     ; export_graph : bool
     ; export_subgraphs : bool
+    ; export_view : Export_view.t
     ; export_timeout : int
     ; parse_env : Cmd_parse.Options.env
     }
@@ -27,12 +28,13 @@ module Options = struct
     | None -> Properties.default_taint_config ()
 
   let env (taint_config' : Fpath.t option) (unsafe_literal_properties' : bool)
-      (no_export : bool) (no_subgraphs : bool) (export_timeout' : int)
-      (parse_env' : Cmd_parse.Options.env) : env =
+      (no_export : bool) (no_subgraphs : bool) (export_view' : Export_view.t)
+      (export_timeout' : int) (parse_env' : Cmd_parse.Options.env) : env =
     { taint_config = parse_taint_config taint_config'
     ; unsafe_literal_properties = unsafe_literal_properties'
     ; export_graph = not no_export
     ; export_subgraphs = not no_subgraphs
+    ; export_view = export_view'
     ; export_timeout = export_timeout'
     ; parse_env = parse_env'
     }
@@ -130,7 +132,10 @@ let builder_env (env : Options.env) : State.Env.t =
   { unsafe_literal_properties = env.unsafe_literal_properties }
 
 let export_env (env : Options.env) : Svg_exporter.Env.t =
-  { subgraphs = env.export_subgraphs; timeout = env.export_timeout }
+  { subgraphs = env.export_subgraphs
+  ; view = env.export_view
+  ; timeout = env.export_timeout
+  }
 
 let read_taint_config (env : Options.env) (w : Workspace.t) :
     Taint_config.t Exec.status =

--- a/src/client/docs.ml
+++ b/src/client/docs.ml
@@ -137,9 +137,10 @@ module ParseOpts = struct
     let doc =
       "Analysis mode used in a Graph.js execution. Options include (1) 'basic' \
        where the attacker controlls all the parameters from all the functions; \
-       (2): 'singlefile' where the attacker controlls the functions exported \
-       by the input file; and (3) 'multifile' where the attacker controlls the \
-       functions that were exported by the 'main' file of the module." in
+       (2): 'singlefile' [default] where the attacker controlls the functions \
+       exported by the input file; and (3) 'multifile' where the attacker \
+       controlls the functions that were exported by the 'main' file of the \
+       module." in
     let modes = Arg.enum Enums.AnalysisMode.(args all) in
     Arg.(value & opt modes SingleFile & info [ "mode" ] ~docv ~doc)
 
@@ -223,6 +224,20 @@ module MdgOpts = struct
   let no_subgraphs =
     let doc = "Run without generating subgraphs in the .svg representation." in
     Arg.(value & flag & info [ "no-subgraphs" ] ~doc)
+
+  let export_view =
+    let docv = "VIEW" in
+    let doc =
+      "Export view when exporting the graph into the .svg representation. \
+       Options include (1) 'full' [default] for exporting the complete graph; \
+       (2) 'calls' for exporting the program's call graph; (3) \
+       'function:<#loc>' for exporting the graph of the function at location \
+       <#loc>; (4) 'object:<#loc>' for exporting the graph of the object at \
+       location <#loc>; and (5) 'reaches:<#loc>' for exporting the subgraph \
+       that reaches the node at location <#loc>." in
+    let parse_f = Enums.ExportView.parse in
+    let default = Enums.ExportView.default () in
+    Arg.(value & opt parse_f default & info [ "export-view" ] ~docv ~doc)
 
   let export_timeout =
     let doc = "Timeout for exporting the graph into the .svg representation." in

--- a/src/client/docs.ml
+++ b/src/client/docs.ml
@@ -230,11 +230,12 @@ module MdgOpts = struct
     let doc =
       "Export view when exporting the graph into the .svg representation. \
        Options include (1) 'full' [default] for exporting the complete graph; \
-       (2) 'calls' for exporting the program's call graph; (3) \
+       (2) 'calls' for exporting the program's call graph; (3) 'object:<#loc>' \
+       for exporting the graph of the object at location <#loc>; (4) \
        'function:<#loc>' for exporting the graph of the function at location \
-       <#loc>; (4) 'object:<#loc>' for exporting the graph of the object at \
-       location <#loc>; and (5) 'reaches:<#loc>' for exporting the subgraph \
-       that reaches the node at location <#loc>." in
+       <#loc>; (5) 'reaches:<#loc>' for exporting the subgraph that reaches \
+       the node at location <#loc>; and (6) 'sinks' for exporting the subgraph \
+       that reaches every tainted sink of the program." in
     let parse_f = Enums.ExportView.parse in
     let default = Enums.ExportView.default () in
     Arg.(value & opt parse_f default & info [ "export-view" ] ~docv ~doc)

--- a/src/client/enums.ml
+++ b/src/client/enums.ml
@@ -9,7 +9,7 @@ module DebugLvl = struct
 
   let all = [ None; Warn; Info; All ]
 
-  let pp (ppf : Fmt.t) debug_lvl : unit =
+  let pp (ppf : Fmt.t) (debug_lvl : t) : unit =
     match debug_lvl with
     | None -> Fmt.pp_str ppf "none"
     | Warn -> Fmt.pp_str ppf "warn"
@@ -37,4 +37,43 @@ module AnalysisMode = struct
 
   let args (modes : t list) : (string * t) list =
     List.map (fun mode -> (str mode, mode)) modes
+end
+
+module ExportView = struct
+  type t = Graphjs_mdg.Export_view.t
+
+  type conv =
+    [ `Ok of t
+    | `Error of string
+    ]
+
+  let default =
+    let dflt = Graphjs_mdg.Export_view.Full in
+    fun () -> dflt
+
+  let pp (ppf : Fmt.t) (view : t) : unit =
+    match view with
+    | Full -> Fmt.pp_str ppf "full"
+    | Calls -> Fmt.pp_str ppf "calls"
+    | Function _ -> Fmt.pp_str ppf "function"
+    | Object _ -> Fmt.pp_str ppf "object"
+    | Reaches _ -> Fmt.pp_str ppf "reaches"
+
+  let conv_param_view (view : string) (prefix : string) : bool =
+    let regex = Str.regexp (Fmt.str "^%s:\\([0-9]+\\)" prefix) in
+    Str.string_match regex view 0
+
+  let conv (view : string) : conv =
+    match view with
+    | "full" -> `Ok Full
+    | "calls" -> `Ok Calls
+    | view' when conv_param_view view "function" ->
+      `Ok (Function (int_of_string (Str.matched_group 1 view')))
+    | view' when conv_param_view view "object" ->
+      `Ok (Object (int_of_string (Str.matched_group 1 view')))
+    | view' when conv_param_view view "reaches" ->
+      `Ok (Reaches (int_of_string (Str.matched_group 1 view')))
+    | _ -> `Error "Invalid export-view argument."
+
+  let parse = (conv, pp)
 end

--- a/src/client/enums.ml
+++ b/src/client/enums.ml
@@ -55,9 +55,10 @@ module ExportView = struct
     match view with
     | Full -> Fmt.pp_str ppf "full"
     | Calls -> Fmt.pp_str ppf "calls"
-    | Function _ -> Fmt.pp_str ppf "function"
     | Object _ -> Fmt.pp_str ppf "object"
+    | Function _ -> Fmt.pp_str ppf "function"
     | Reaches _ -> Fmt.pp_str ppf "reaches"
+    | Sinks -> Fmt.pp_str ppf "sinks"
 
   let conv_param_view (view : string) (prefix : string) : bool =
     let regex = Str.regexp (Fmt.str "^%s:\\([0-9]+\\)" prefix) in
@@ -67,10 +68,11 @@ module ExportView = struct
     match view with
     | "full" -> `Ok Full
     | "calls" -> `Ok Calls
-    | view' when conv_param_view view "function" ->
-      `Ok (Function (int_of_string (Str.matched_group 1 view')))
+    | "sinks" -> `Ok Sinks
     | view' when conv_param_view view "object" ->
       `Ok (Object (int_of_string (Str.matched_group 1 view')))
+    | view' when conv_param_view view "function" ->
+      `Ok (Function (int_of_string (Str.matched_group 1 view')))
     | view' when conv_param_view view "reaches" ->
       `Ok (Reaches (int_of_string (Str.matched_group 1 view')))
     | _ -> `Error "Invalid export-view argument."

--- a/src/client/utils/exec.ml
+++ b/src/client/utils/exec.ml
@@ -45,6 +45,7 @@ let graphjs (exec_f : unit -> 'a) : 'a status =
   | Graphjs_parser.Flow_parser.Exn fmt -> exn (`ParseJS fmt)
   | Graphjs_mdg.Svg_exporter.Exn fmt -> exn (`ExportMDG fmt)
   | Graphjs_mdg.Svg_exporter.Timeout -> exn `Timeout
+  | Graphjs_mdg.Export_view.Exn fmt -> exn (`ExportMDG fmt)
   | err ->
     let msg = Printexc.to_string err in
     let trace = Printexc.get_backtrace () in

--- a/src/client/utils/fs.ml
+++ b/src/client/utils/fs.ml
@@ -9,13 +9,13 @@ module Parser = struct
 
   let check (check_f : Fpath.t -> bool) (kind : string) (fpath : t) : conv =
     if check_f fpath then `Ok fpath
-    else `Error (Fmt.str "Path '%a' is not a valid %s!" pp fpath kind)
+    else `Error (Fmt.str "Path '%a' is not a valid %s." pp fpath kind)
 
   let parse (parse_f : t -> (bool, [< `Msg of string ]) Result.t)
       (kind : string) (fpath : t) : conv =
     match parse_f fpath with
     | Ok true -> `Ok fpath
-    | Ok false -> `Error (Fmt.str "%s '%a' not found!" kind pp fpath)
+    | Ok false -> `Error (Fmt.str "%s '%a' not found." kind pp fpath)
     | Error (`Msg err) -> `Error err
 
   let fix_dir (fpath : t) : t =

--- a/src/graphjs.ml
+++ b/src/graphjs.ml
@@ -68,6 +68,7 @@ let mdg_env =
   $ Docs.MdgOpts.unsafe_literal_properties
   $ Docs.MdgOpts.no_export
   $ Docs.MdgOpts.no_subgraphs
+  $ Docs.MdgOpts.export_view
   $ Docs.MdgOpts.export_timeout
   $ parse_env
 

--- a/src/mdg/dune
+++ b/src/mdg/dune
@@ -11,6 +11,7 @@
   mdg
   store
   state
+  export_view
   svg_exporter
   builder
   merger

--- a/src/mdg/export/export_view.ml
+++ b/src/mdg/export/export_view.ml
@@ -1,0 +1,121 @@
+open Graphjs_base
+
+exception Exn of (Fmt.t -> unit)
+
+let raise (fmt : ('b, Fmt.t, unit, 'a) format4) : 'b =
+  let raise_f acc = raise (Exn acc) in
+  let err_f acc = fun ppf -> Log.fmt_error ppf "%t for export view." acc in
+  Fmt.kdly (fun acc -> raise_f (err_f acc)) fmt
+
+let get_node (mdg : Mdg.t) (loc : Location.t) : Node.t =
+  try Mdg.get_node mdg loc
+  with _ -> raise "Non-existing node location '%a'" Location.pp loc
+
+module GraphNode = struct
+  type t = Node.t
+
+  let hash = Node.hash
+  let equal = Node.equal
+  let compare = Node.compare
+end
+
+module GraphEdge = struct
+  type t = Edge.t
+
+  let default = Edge.default ()
+  let compare = Edge.compare
+end
+
+module G =
+  Graph.Persistent.Digraph.ConcreteBidirectionalLabeled (GraphNode) (GraphEdge)
+
+module Default = struct
+  let build_graph_node (node : Node.t) (graph : G.t) : G.t =
+    G.add_vertex graph node
+
+  let build_graph_edge (edge : Edge.t) (graph : G.t) : G.t =
+    G.add_edge_e graph (G.E.create edge.src edge edge.tar)
+
+  let build_graph (mdg : Mdg.t) : G.t =
+    Hashtbl.fold (fun _ -> build_graph_node) mdg.nodes G.empty
+    |> Hashtbl.fold (fun _ -> Edge.Set.fold build_graph_edge) mdg.edges
+end
+
+module Calls = struct
+  let build_graph_node (node : Node.t) (graph : G.t) : G.t =
+    match node.kind with
+    | Function _ | Call _ -> G.add_vertex graph node
+    | _ -> graph
+
+  let build_graph_edge (edge : Edge.t) (graph : G.t) : G.t =
+    match edge.kind with
+    | Caller -> G.add_edge_e graph (G.E.create edge.src edge edge.tar)
+    | _ -> graph
+
+  let build_graph (mdg : Mdg.t) : G.t =
+    Hashtbl.fold (fun _ -> build_graph_node) mdg.nodes G.empty
+    |> Hashtbl.fold (fun _ -> Edge.Set.fold build_graph_edge) mdg.edges
+end
+
+module Function = struct
+  let get_function (mdg : Mdg.t) (uid : Location.t) : Node.t =
+    let l_func = get_node mdg uid in
+    match l_func.kind with
+    | Function _ -> l_func
+    | _ -> raise "Unexpected non-function node '%a'" Node.pp l_func
+
+  let in_function (l_func : Node.t) (node : Node.t) : bool =
+    Node.equal l_func node || Option.equal Node.equal (Some l_func) node.parent
+
+  let build_graph_node (l_func : Node.t) (node : Node.t) (graph : G.t) : G.t =
+    if in_function l_func node then G.add_vertex graph node else graph
+
+  let build_graph_edge (l_func : Node.t) (edge : Edge.t) (graph : G.t) : G.t =
+    if in_function l_func edge.src || in_function l_func edge.tar then
+      G.add_edge_e graph (G.E.create edge.src edge edge.tar)
+    else graph
+
+  let build_graph (mdg : Mdg.t) (loc : Location.t) : G.t =
+    let l_node = get_function mdg loc in
+    Hashtbl.fold (fun _ -> build_graph_node l_node) mdg.nodes G.empty
+    |> Hashtbl.fold (fun _ -> Edge.Set.fold (build_graph_edge l_node)) mdg.edges
+end
+
+module Flow = struct
+  type worklist = Node.t Queue.t
+  type visited = (Location.t, unit) Hashtbl.t
+
+  let visit_f (_ : Edge.t) : bool = true
+  let node_f (node : Node.t) (graph : G.t) : G.t = G.add_vertex graph node
+
+  let edge_f (tran : Edge.t) (graph : G.t) : G.t =
+    let edge = Edge.transpose tran in
+    G.add_edge_e graph (G.E.create edge.src edge edge.tar)
+
+  let build_graph (mdg : Mdg.t) (loc : Location.t) : G.t =
+    let node = get_node mdg loc in
+    Mdg.visit_backwards visit_f node_f edge_f mdg node G.empty
+end
+
+module Object = struct
+  type worklist = Node.t Queue.t
+  type visited = (Location.t, unit) Hashtbl.t
+
+  let get_object (mdg : Mdg.t) (uid : Location.t) : Node.t =
+    let l_obj = get_node mdg uid in
+    match l_obj.kind with
+    | Object _ | Function _ | Parameter _ | Return _ -> l_obj
+    | _ -> raise "Unexpected non-object node '%a'" Node.pp l_obj
+
+  let visit_f (edge : Edge.t) : bool =
+    match edge.kind with Property _ | Version _ -> true | _ -> false
+
+  let node_f (node : Node.t) (graph : G.t) : G.t = G.add_vertex graph node
+
+  let edge_f (edge : Edge.t) (graph : G.t) : G.t =
+    G.add_edge_e graph (G.E.create edge.src edge edge.tar)
+
+  let build_graph (mdg : Mdg.t) (loc : Location.t) : G.t =
+    let node = get_object mdg loc in
+    Mdg.visit_forwards visit_f node_f edge_f mdg node G.empty
+end

--- a/src/mdg/export/svg_exporter.ml
+++ b/src/mdg/export/svg_exporter.ml
@@ -145,9 +145,10 @@ let build_graph (env : Env.t) (mdg : Mdg.t) : Export_view.G.t =
   match env.view with
   | Full -> Export_view.Full.build_graph mdg
   | Calls -> Export_view.Calls.build_graph mdg
-  | Function loc -> Export_view.Function.build_graph mdg loc
   | Object loc -> Export_view.Object.build_graph mdg loc
+  | Function loc -> Export_view.Function.build_graph mdg loc
   | Reaches loc -> Export_view.Reaches.build_graph mdg loc
+  | Sinks -> Export_view.Sinks.build_graph mdg
 
 let svg_cmd (env : Env.t) (svg : string) (dot : string) : string =
   Fmt.str "timeout %d dot -Tsvg %s -o %s 2>/dev/null" env.timeout dot svg

--- a/src/mdg/graph/mdg.ml
+++ b/src/mdg/graph/mdg.ml
@@ -213,6 +213,47 @@ let get_function_returns (mdg : t) (node : Node.t) : Node.t list =
   |> Edge.Set.filter Edge.is_return
   |> Edge.Set.map_list Edge.tar
 
+let visit (visit_f : Edge.t -> bool) (node_f : Node.t -> 'a -> 'a)
+    (edge_f : Edge.t -> 'a -> 'a) (mdg : t) (nodes : Node.t list) (acc : 'a)
+    (forward : bool) : 'a =
+  let get_edges_f = if forward then get_edges else get_trans in
+  let worklist = Queue.create () in
+  let visited = Hashtbl.create Config.(!dflt_htbl_sz) in
+  List.iter (fun node -> Queue.add node worklist) nodes;
+  List.iter (fun node -> Hashtbl.add visited (Node.uid node) ()) nodes;
+  let visit_edge edge acc =
+    if visit_f edge then (
+      if not (Hashtbl.mem visited edge.tar.uid) then (
+        Queue.add edge.tar worklist;
+        Hashtbl.add visited edge.tar.uid () );
+      edge_f edge acc )
+    else acc in
+  let visit_node node acc =
+    let acc' = node_f node acc in
+    Edge.Set.fold visit_edge (get_edges_f mdg node.uid) acc' in
+  let rec visit_nodes acc =
+    Option.fold (Queue.take_opt worklist) ~none:acc ~some:(fun node ->
+        visit_nodes (visit_node node acc) ) in
+  visit_nodes acc
+
+let visit_forwards (visit_f : Edge.t -> bool) (node_f : Node.t -> 'a -> 'a)
+    (edge_f : Edge.t -> 'a -> 'a) (mdg : t) (node : Node.t) (acc : 'a) : 'a =
+  visit visit_f node_f edge_f mdg [ node ] acc true
+
+let visit_backwards (visit_f : Edge.t -> bool) (node_f : Node.t -> 'a -> 'a)
+    (edge_f : Edge.t -> 'a -> 'a) (mdg : t) (node : Node.t) (acc : 'a) : 'a =
+  visit visit_f node_f edge_f mdg [ node ] acc false
+
+let visit_multiple_forwards (visit_f : Edge.t -> bool)
+    (node_f : Node.t -> 'a -> 'a) (edge_f : Edge.t -> 'a -> 'a) (mdg : t)
+    (nodes : Node.t list) (acc : 'a) : 'a =
+  visit visit_f node_f edge_f mdg nodes acc true
+
+let visit_multiple_backwards (visit_f : Edge.t -> bool)
+    (node_f : Node.t -> 'a -> 'a) (edge_f : Edge.t -> 'a -> 'a) (mdg : t)
+    (nodes : Node.t list) (acc : 'a) : 'a =
+  visit visit_f node_f edge_f mdg nodes acc false
+
 let object_parents_traversal (f : Node.Set.t -> Node.t -> 'a -> 'a) (mdg : t)
     (ls_visited : Node.Set.t) (node : Node.t) (acc : 'a) : 'a =
   Fun.flip2 List.fold_left acc (get_parents mdg node) (fun acc (_, l_parent) ->
@@ -303,34 +344,3 @@ let object_lookup (mdg : t) (node : Node.t) (prop : Property.t) : Node.Set.t =
   match prop with
   | Static prop' -> object_static_lookup mdg node prop'
   | Dynamic -> object_dynamic_lookup mdg node
-
-let visit (visit_f : Edge.t -> bool) (node_f : Node.t -> 'a -> 'a)
-    (edge_f : Edge.t -> 'a -> 'a) (mdg : t) (node : Node.t) (acc : 'a)
-    (forward : bool) : 'a =
-  let get_edges = if forward then get_edges else get_trans in
-  let worklist = Queue.create () in
-  let visited = Hashtbl.create Config.(!dflt_htbl_sz) in
-  Queue.add node worklist;
-  Hashtbl.add visited node.uid ();
-  let visit_edge edge acc =
-    if visit_f edge then (
-      if not (Hashtbl.mem visited edge.tar.uid) then (
-        Queue.add edge.tar worklist;
-        Hashtbl.add visited edge.tar.uid () );
-      edge_f edge acc )
-    else acc in
-  let visit_node node acc =
-    let acc' = node_f node acc in
-    Edge.Set.fold visit_edge (get_edges mdg node.uid) acc' in
-  let rec visit_nodes acc =
-    Option.fold (Queue.take_opt worklist) ~none:acc ~some:(fun node ->
-        visit_nodes (visit_node node acc) ) in
-  visit_nodes acc
-
-let visit_forwards (visit_f : Edge.t -> bool) (node_f : Node.t -> 'a -> 'a)
-    (edge_f : Edge.t -> 'a -> 'a) (mdg : t) (node : Node.t) (acc : 'a) : 'a =
-  visit visit_f node_f edge_f mdg node acc true
-
-let visit_backwards (visit_f : Edge.t -> bool) (node_f : Node.t -> 'a -> 'a)
-    (edge_f : Edge.t -> 'a -> 'a) (mdg : t) (node : Node.t) (acc : 'a) : 'a =
-  visit visit_f node_f edge_f mdg node acc false


### PR DESCRIPTION
This implements multiple export views to reduce the size of the exporter graph according to certain restrictions. The implemented views are:
- Full
- Calls
- Object:\<node\>
- Function:\<node\>
- Reaches:\<node\>
- Sinks