### PR TITLE
Add ids to the AST Metadata

### DIFF
--- a/src/ast/ast.ml
+++ b/src/ast/ast.ml
@@ -31,12 +31,12 @@ and Prop : sig
 
   and t' =
     | IProp of Identifier.t'
-    | LProp of Expression.Literal.t
+    | LProp of Expression.LiteralValue.t
 end =
   Prop
 
 and Expression : sig
-  module Literal : sig
+  module LiteralValue : sig
     module Regex : sig
       type t =
         { pattern : string
@@ -88,7 +88,7 @@ and Expression : sig
   type 'm t = ('m, 'm t') Metadata.t
 
   and 'm t' =
-    [ `Literal of Literal.t
+    [ `LiteralValue of LiteralValue.t
     | `TemplateLiteral of 'm TemplateLiteral.t
     | `Identifier of Identifier.t'
     | `This of This.t

--- a/src/ast/ast.ml
+++ b/src/ast/ast.ml
@@ -1,5 +1,5 @@
 module rec Identifier : sig
-  type 'm t = ('m, t') Metadata.t
+  type 'm t = (t', 'm) Metadata.t
 
   and t' =
     { name : string
@@ -17,7 +17,7 @@ and LeftValue : sig
       | None
   end
 
-  type 'm t = ('m, t') Metadata.t
+  type 'm t = (t', 'm) Metadata.t
 
   and t' =
     { id : Identifier.t'
@@ -27,7 +27,7 @@ end =
   LeftValue
 
 and Prop : sig
-  type 'm t = ('m, t') Metadata.t
+  type 'm t = (t', 'm) Metadata.t
 
   and t' =
     | IProp of Identifier.t'
@@ -67,7 +67,7 @@ and Expression : sig
           }
       end
 
-      type 'm t = ('m, t') Metadata.t
+      type 'm t = (t', 'm) Metadata.t
 
       and t' =
         { value : Value.t
@@ -85,7 +85,7 @@ and Expression : sig
     type t = unit
   end
 
-  type 'm t = ('m, 'm t') Metadata.t
+  type 'm t = ('m t', 'm) Metadata.t
 
   and 'm t' =
     [ `LiteralValue of LiteralValue.t
@@ -254,7 +254,7 @@ and Statement : sig
 
   module Switch : sig
     module Case : sig
-      type 'm t = ('m, 'm t') Metadata.t
+      type 'm t = ('m t', 'm) Metadata.t
 
       and 'm t' =
         { test : 'm Expression.t option
@@ -310,7 +310,7 @@ and Statement : sig
 
   module Try : sig
     module Catch : sig
-      type 'm t = ('m, 'm t') Metadata.t
+      type 'm t = ('m t', 'm) Metadata.t
 
       and 'm t' =
         { param : 'm Identifier.t option
@@ -374,7 +374,7 @@ and Statement : sig
       }
   end
 
-  type 'm t = ('m, 'm t') Metadata.t
+  type 'm t = ('m t', 'm) Metadata.t
 
   and 'm t' =
     [ `ExprStmt of 'm Expression.t'

--- a/src/ast/graphjs_ast.ml
+++ b/src/ast/graphjs_ast.ml
@@ -91,15 +91,15 @@ module Prop = struct
 end
 
 module Regex = struct
-  include Ast.Expression.Literal.Regex
+  include Ast.Expression.LiteralValue.Regex
 
   let create (pattern : string) (flags : string) : t = { pattern; flags }
   let pp (ppf : Fmt.t) (regex : t) : unit = Printer.pp_regex ppf regex
   let str (regex : t) : string = Fmt.str "%a" pp regex
 end
 
-module Literal = struct
-  include Ast.Expression.Literal
+module LiteralValue = struct
+  include Ast.Expression.LiteralValue
 
   let create (value : t') (raw : string) : t = { value; raw }
   let null () : t = create Null "null"
@@ -114,7 +114,7 @@ module Literal = struct
   let integer (value : int) : t =
     create (Number (float_of_int value)) (string_of_int value)
 
-  let to_expr (lit : t) : 'm Ast.Expression.t' = `Literal lit
+  let to_expr (literal : t) : 'm Ast.Expression.t' = `LiteralValue literal
   let pp (ppf : Fmt.t) (literal : t) : unit = Printer.pp_literal ppf literal
   let str (literal : t) : string = Fmt.str "%a" pp literal
 end
@@ -147,8 +147,8 @@ module TemplateElement = struct
   let to_expr (telement : 'm t) : 'm Ast.Expression.t' =
     let value = telement.el.value.raw in
     let raw = Fmt.str "%S" value in
-    let literal = Literal.string value raw in
-    Literal.to_expr literal
+    let literal = LiteralValue.string value raw in
+    LiteralValue.to_expr literal
 
   let pp (ppf : Fmt.t) (telement : 'm t) : unit =
     Printer.pp_template_element ppf telement

--- a/src/ast/metadata.ml
+++ b/src/ast/metadata.ml
@@ -1,9 +1,20 @@
-type ('m, 'e) t =
-  { md : 'm
+open Graphjs_base
+
+module Config = struct
+  include Config
+
+  let id_gen = constant (Generator.of_numbers ~init:1 ())
+end
+
+type ('e, 'm) t =
+  { id : int
   ; el : 'e
+  ; md : 'm
   }
 
-let ( @> ) (el : 'e) (md : 'm) : ('m, 'e) t = { el; md }
-let el (x : ('m, 'e) t) : 'e = x.el
-let md (x : ('m, 'e) t) : 'm = x.md
-let map (f : 'e -> 'f) (x : ('m, 'e) t) : ('m, 'f) t = f x.el @> x.md
+let ( @> ) (el : 'e) (md : 'm) : ('e, 'm) t =
+  let id = Config.(!id_gen).next () in
+  { id; el; md }
+
+let el (x : ('e, 'm) t) : 'e = x.el
+let md (x : ('e, 'm) t) : 'm = x.md

--- a/src/ast/printer.ml
+++ b/src/ast/printer.ml
@@ -43,10 +43,10 @@ and pp_prop_access (ppf : Fmt.t) (prop : 'm Prop.t) : unit =
   | IProp id -> Fmt.fmt ppf ".%a" pp_identifier' id
   | LProp lit -> Fmt.fmt ppf "[%a]" pp_literal lit
 
-and pp_literal (ppf : Fmt.t) (literal : Expression.Literal.t) : unit =
+and pp_literal (ppf : Fmt.t) (literal : Expression.LiteralValue.t) : unit =
   Fmt.pp_str ppf literal.raw
 
-and pp_regex (ppf : Fmt.t) (regex : Expression.Literal.Regex.t) : unit =
+and pp_regex (ppf : Fmt.t) (regex : Expression.LiteralValue.Regex.t) : unit =
   Fmt.fmt ppf "/%s/%s" regex.pattern regex.flags
 
 and pp_template_literal (ppf : Fmt.t)
@@ -72,7 +72,7 @@ and pp_expr (ppf : Fmt.t) (expr : 'm Expression.t) : unit = pp_expr' ppf expr.el
 
 and pp_expr' (ppf : Fmt.t) (expr : 'm Expression.t') : unit =
   match expr with
-  | `Literal literal -> pp_literal ppf literal
+  | `LiteralValue literal -> pp_literal ppf literal
   | `TemplateLiteral tliteral -> pp_template_literal ppf tliteral
   | `Identifier id -> pp_identifier' ppf id
   | `This () -> pp_this ppf ()

--- a/src/mdg/builder.ml
+++ b/src/mdg/builder.ml
@@ -148,7 +148,7 @@ let call_interceptor (state : State.t) (ls_func : Node.Set.t) (l_call : Node.t)
 let rec eval_expr (state : State.t) (expr : 'm Expression.t) : Node.Set.t =
   let exprs_f acc expr = Node.Set.union acc (eval_expr state expr) in
   match expr.el with
-  | `Literal _ -> eval_literal_expr state
+  | `LiteralValue _ -> eval_literal_expr state
   | `TemplateLiteral { exprs; _ } -> List.fold_left exprs_f Node.Set.empty exprs
   | `Identifier id -> eval_store_expr state (Identifier.name' id)
   | `This _ -> eval_store_expr state "this"

--- a/src/mdg/domain/registry.ml
+++ b/src/mdg/domain/registry.ml
@@ -1,0 +1,29 @@
+open Graphjs_base
+open Graphjs_ast
+
+type cid =
+  { id : int
+  ; offset : int
+  ; at : Region.t
+  }
+
+include Hashtbl.Make (struct
+  type t = cid
+
+  let hash (key : t) : int = Hashtbl.hash (key.id, key.offset)
+
+  let equal (key1 : t) (key2 : t) : bool =
+    Int.equal key1.id key2.id && Int.equal key1.offset key2.offset
+end)
+
+let cid (el : ('a, Region.t) Metadata.t) : cid =
+  { id = el.id; offset = 0; at = el.md }
+
+let offset (cid : cid) (offset : int) : cid = { cid with offset }
+let at (cid : cid) : Region.t = cid.at
+
+let lub (reg1 : 'a t) (reg2 : 'a t) : 'a t =
+  Fun.flip iter reg2 (fun stmt node2 ->
+      let el1 = find_opt reg1 stmt in
+      if Option.is_none el1 then replace reg1 stmt node2 );
+  reg1

--- a/src/mdg/domain/state.ml
+++ b/src/mdg/domain/state.ml
@@ -9,34 +9,11 @@ module Env = struct
     fun () -> dflt
 end
 
-module GraphRegistry = struct
-  type id = Region.t Statement.t * int
-  type t = (id, Node.t) Hashtbl.t
-
-  let cid (stmt : 'a Statement.t) : id = (stmt, 0)
-  let offset (cid : id) (offset : int) : id = (fst cid, offset)
-  let at (cid : id) : Region.t = Metadata.md (fst cid)
-  let create () : t = Hashtbl.create Config.(!dflt_htbl_sz)
-  let copy (cache : t) : t = Hashtbl.copy cache
-
-  let find_node (cache : t) (id : id) : Node.t option =
-    Hashtbl.find_opt cache id
-
-  let add_node (cache : t) (id : id) (node : Node.t) : unit =
-    Hashtbl.replace cache id node
-
-  let lub (cache1 : t) (cache2 : t) : t =
-    Fun.flip Hashtbl.iter cache2 (fun stmt node2 ->
-        let node1 = Hashtbl.find_opt cache1 stmt in
-        if Option.is_none node1 then Hashtbl.replace cache1 stmt node2 );
-    cache1
-end
-
 type t =
   { env : Env.t
   ; mdg : Mdg.t
   ; store : Store.t
-  ; registry : GraphRegistry.t
+  ; registry : Node.t Registry.t
   ; lookup_interceptors : (Location.t, lookup_interceptor) Hashtbl.t
   ; call_interceptors : (Location.t, call_interceptor) Hashtbl.t
   ; curr_func : Node.t option
@@ -52,14 +29,14 @@ and call_interceptor =
   -> Node.t
   -> Node.Set.t list
   -> Region.t Expression.t list
-  -> GraphRegistry.id
+  -> Registry.cid
   -> t
 
 let create (env' : Env.t) : t =
   { env = env'
   ; mdg = Mdg.create ()
   ; store = Store.create ()
-  ; registry = GraphRegistry.create ()
+  ; registry = Registry.create Config.(!dflt_htbl_sz)
   ; lookup_interceptors = Hashtbl.create Config.(!dflt_htbl_sz)
   ; call_interceptors = Hashtbl.create Config.(!dflt_htbl_sz)
   ; curr_func = None
@@ -68,41 +45,41 @@ let create (env' : Env.t) : t =
 let initialize (state : t) : t =
   let mdg = Mdg.copy state.mdg in
   let store = Store.copy state.store in
-  let registry = GraphRegistry.copy state.registry in
+  let registry = Registry.copy state.registry in
   let curr_func = None in
   { state with mdg; store; registry; curr_func }
 
 let copy (state : t) : t =
   let mdg = Mdg.copy state.mdg in
   let store = Store.copy state.store in
-  let registry = GraphRegistry.copy state.registry in
+  let registry = Registry.copy state.registry in
   { state with mdg; store; registry }
 
 let join (state1 : t) (state2 : t) : t =
   let mdg = Mdg.join state1.mdg state2.mdg in
-  let registry = GraphRegistry.lub state1.registry state2.registry in
+  let registry = Registry.lub state1.registry state2.registry in
   { state1 with mdg; registry }
 
 let lub (state1 : t) (state2 : t) : t =
   let mdg = Mdg.lub state1.mdg state2.mdg in
   let store = Store.lub state1.store state2.store in
-  let registry = GraphRegistry.lub state1.registry state2.registry in
+  let registry = Registry.lub state1.registry state2.registry in
   { state1 with mdg; store; registry }
 
-let get_node (state : t) (id : GraphRegistry.id) : Node.t =
-  match GraphRegistry.find_node state.registry id with
+let get_node (state : t) (id : Registry.cid) : Node.t =
+  match Registry.find_opt state.registry id with
   | None ->
-    let at = GraphRegistry.at id in
+    let at = Registry.at id in
     Log.fail "expecting node of region '%a' in registry" Region.pp at
   | Some node -> node
 
-let add_node (state : t) (id : GraphRegistry.id)
+let add_node (state : t) (id : Registry.cid)
     (create_node_f : Node.t option -> Region.t -> Node.t) : Node.t =
-  match GraphRegistry.find_node state.registry id with
+  match Registry.find_opt state.registry id with
   | Some node -> node
   | None ->
-    let node = create_node_f state.curr_func (GraphRegistry.at id) in
-    GraphRegistry.add_node state.registry id node;
+    let node = create_node_f state.curr_func (Registry.at id) in
+    Registry.replace state.registry id node;
     Mdg.add_node state.mdg node;
     node
 
@@ -112,29 +89,28 @@ let add_edge (state : t) (src : Node.t) (tar : Node.t)
   Mdg.add_edge state.mdg edge;
   edge
 
-let add_object_node (st : t) (id : GraphRegistry.id) (name : string) : Node.t =
+let add_object_node (st : t) (id : Registry.cid) (name : string) : Node.t =
   add_node st id (Node.create_object name)
 
-let add_literal_object_node (state : t) (id : GraphRegistry.id) (name : string)
-    : Node.t =
+let add_literal_object_node (state : t) (id : Registry.cid) (name : string) :
+    Node.t =
   add_node state id (Node.create_literal_object name)
 
-let add_function_node (state : t) (id : GraphRegistry.id) (name : string) :
-    Node.t =
+let add_function_node (state : t) (id : Registry.cid) (name : string) : Node.t =
   add_node state id (Node.create_function name)
 
-let add_parameter_node (state : t) (id : GraphRegistry.id) (idx : int)
+let add_parameter_node (state : t) (id : Registry.cid) (idx : int)
     (name : string) : Node.t =
   add_node state id (Node.create_parameter idx name)
 
-let add_call_node (state : t) (id : GraphRegistry.id) (name : string) : Node.t =
+let add_call_node (state : t) (id : Registry.cid) (name : string) : Node.t =
   add_node state id (Node.create_call name)
 
-let add_return_node (st : t) (id : GraphRegistry.id) (name : string) : Node.t =
+let add_return_node (st : t) (id : Registry.cid) (name : string) : Node.t =
   add_node st id (Node.create_return name)
 
-let add_import_node (state : t) (id : GraphRegistry.id) (name : string) :
-    t * Node.t =
+let add_import_node (state : t) (id : Registry.cid) (name : string) : t * Node.t
+    =
   let node = add_node state id (Node.create_import name) in
   ({ state with mdg = Mdg.add_imports state.mdg node }, node)
 

--- a/src/mdg/dune
+++ b/src/mdg/dune
@@ -10,6 +10,7 @@
   edge
   mdg
   store
+  registry
   state
   export_view
   svg_exporter

--- a/src/mdg/jslib.ml
+++ b/src/mdg/jslib.ml
@@ -62,8 +62,9 @@ end
 module CallInterceptor = struct
   let require (state : State.t) (_ : Node.t) (_ : Node.t) (l_retn : Node.t)
       (_ : Node.Set.t list) (es : 'm Expression.t list) (cid : cid) : State.t =
+    let open Metadata in
     match es with
-    | Metadata.{ el = `Literal Literal.{ value = String arg; _ }; _ } :: _ ->
+    | { el = `LiteralValue LiteralValue.{ value = String arg; _ }; _ } :: _ ->
       let (state', l_require) = State.add_import_node state cid arg in
       State.add_dependency_edge state' l_require l_retn;
       state'

--- a/src/mdg/jslib.ml
+++ b/src/mdg/jslib.ml
@@ -2,7 +2,7 @@ open Graphjs_base
 open Graphjs_share
 open Graphjs_ast
 
-type cid = State.GraphRegistry.id
+type cid = Registry.cid
 
 module LookupInterceptor = struct
   let get_temp_exports (state : State.t) (l_exports : Node.t option)

--- a/src/parser/normalizer.ml
+++ b/src/parser/normalizer.ml
@@ -168,7 +168,7 @@ let get_property_expr (n_prop : prop) : expr' =
 
 let get_stmt_lvals (n_stmts : n_stmt) : lval list =
   Fun.flip List.filter_map n_stmts (function
-    | { el = `VarDecl vdecl; md } -> Some (vdecl @> md)
+    | { el = `VarDecl vdecl; md; _ } -> Some (vdecl @> md)
     | { el = `Assignment assign; _ } -> Some assign.left
     | { el = `NewObject obj; _ } -> Some obj.left
     | { el = `NewArray arr; _ } -> Some arr.left
@@ -191,37 +191,37 @@ let initialize_stmts_lvals (n_stmts : n_stmt) : n_stmt =
   let ( @> ) el md = Some (el @> md) in
   Fun.flip List.filter_map n_stmts (function
     | { el = `VarDecl _; _ } -> None
-    | { el = `Assignment el; md } ->
+    | { el = `Assignment el; md; _ } ->
       `Assignment { el with left = LeftValue.initialize el.left } @> md
-    | { el = `NewObject el; md } ->
+    | { el = `NewObject el; md; _ } ->
       NewObject.create_stmt (LeftValue.initialize el.left) @> md
-    | { el = `NewArray el; md } ->
+    | { el = `NewArray el; md; _ } ->
       NewArray.create_stmt (LeftValue.initialize el.left) @> md
-    | { el = `Unopt el; md } ->
+    | { el = `Unopt el; md; _ } ->
       `Unopt { el with left = LeftValue.initialize el.left } @> md
-    | { el = `Binopt el; md } ->
+    | { el = `Binopt el; md; _ } ->
       `Binopt { el with left = LeftValue.initialize el.left } @> md
-    | { el = `Yield el; md } ->
+    | { el = `Yield el; md; _ } ->
       `Yield { el with left = LeftValue.initialize el.left } @> md
-    | { el = `StaticLookup el; md } ->
+    | { el = `StaticLookup el; md; _ } ->
       `StaticLookup { el with left = LeftValue.initialize el.left } @> md
-    | { el = `DynamicLookup el; md } ->
+    | { el = `DynamicLookup el; md; _ } ->
       `DynamicLookup { el with left = LeftValue.initialize el.left } @> md
-    | { el = `StaticDelete el; md } ->
+    | { el = `StaticDelete el; md; _ } ->
       `StaticDelete { el with left = LeftValue.initialize el.left } @> md
-    | { el = `DynamicDelete el; md } ->
+    | { el = `DynamicDelete el; md; _ } ->
       `DynamicDelete { el with left = LeftValue.initialize el.left } @> md
-    | { el = `NewCall el; md } ->
+    | { el = `NewCall el; md; _ } ->
       `NewCall { el with left = LeftValue.initialize el.left } @> md
-    | { el = `FunctionCall el; md } ->
+    | { el = `FunctionCall el; md; _ } ->
       `FunctionCall { el with left = LeftValue.initialize el.left } @> md
-    | { el = `StaticMethodCall el; md } ->
+    | { el = `StaticMethodCall el; md; _ } ->
       `StaticMethodCall { el with left = LeftValue.initialize el.left } @> md
-    | { el = `DynamicMethodCall el; md } ->
+    | { el = `DynamicMethodCall el; md; _ } ->
       `DynamicMethodCall { el with left = LeftValue.initialize el.left } @> md
-    | { el = `FunctionDefinition el; md } ->
+    | { el = `FunctionDefinition el; md; _ } ->
       `FunctionDefinition { el with left = LeftValue.initialize el.left } @> md
-    | { el = `DynamicImport el; md } ->
+    | { el = `DynamicImport el; md; _ } ->
       `DynamicImport { el with left = LeftValue.initialize el.left } @> md
     | n_stmt -> Some n_stmt )
 
@@ -231,7 +231,7 @@ let normalize_location (loc : Loc.t) : md =
   let rpos = Region.create_pos loc._end.line loc._end.column in
   Region.create file lpos rpos
 
-let ( @!> ) (el : 'e) (loc : Loc.t) : (md, 'e) Metadata.t =
+let ( @!> ) (el : 'e) (loc : Loc.t) : ('e, md) Metadata.t =
   el @> normalize_location loc
 
 let rec leftvalue_ctx (ctx : Ctx.t) :


### PR DESCRIPTION
This PR adds ids to the metadata of every element from the normalized JavaScript AST. Additionally, it now uses these ids in the node registry to prevent multiple node allocations for the same construct.