### PR TITLE
Add callbacks to the component entry points

### DIFF
--- a/src/ast/graphjs_ast.ml
+++ b/src/ast/graphjs_ast.ml
@@ -750,7 +750,7 @@ module Prog = struct
   let create (files : (Fpath.t * 'm File.t) list) : 'm t =
     files |> List.to_seq |> Hashtbl.of_seq
 
-  let length (prog : 'm t) : int = Hashtbl.length prog
+  let is_multifile (prog : 'm t) : bool = Hashtbl.length prog > 1
 
   let find (prog : 'm t) (path : Fpath.t) : 'm Ast.File.t =
     Hashtbl.find prog path

--- a/src/client/cmd_analyze.ml
+++ b/src/client/cmd_analyze.ml
@@ -42,7 +42,7 @@ module Output = struct
 end
 
 let run (env : Options.env) (w : Workspace.t) (input : Fpath.t) :
-    unit Exec.status =
+    unit Exec.result =
   let* mdg = Cmd_mdg.run env.mdg_env (Workspace.side_perm w) input in
   let _engine = Analysis_engine.initialize mdg in
   (* Output.tainted w engine; *)
@@ -50,7 +50,7 @@ let run (env : Options.env) (w : Workspace.t) (input : Fpath.t) :
   (* Output.main w input vulns; *)
   Ok ()
 
-let outcome (result : 'a Exec.status) : Bulk.Instance.outcome =
+let outcome (result : 'a Exec.result) : Bulk.Instance.outcome =
   match result with
   | Ok _ -> Success
   | Error (`DepTree _) -> Anomaly
@@ -67,7 +67,7 @@ let bulk_interface (env : Options.env) : (module Bulk.CmdInterface) =
     let outcome = outcome
   end )
 
-let main (opts : Options.t) () : unit Exec.status =
+let main (opts : Options.t) () : unit Exec.result =
   let w = Workspace.create ~default:`None opts.inputs opts.output in
   let* _ = Workspace.prepare w in
   let* inputs = Bulk.InputTree.generate opts.inputs in

--- a/src/client/cmd_dependencies.ml
+++ b/src/client/cmd_dependencies.ml
@@ -37,18 +37,18 @@ let dep_tree (path : Fpath.t) (mode : Analysis_mode.t) () : Dependency_tree.t =
   Dependency_tree.generate mode path
 
 let generate_dep_tree (env : Options.env) (w : Workspace.t)
-    (mode : Analysis_mode.t) (path : Fpath.t) : Dependency_tree.t Exec.status =
+    (mode : Analysis_mode.t) (path : Fpath.t) : Dependency_tree.t Exec.result =
   let* dt = Exec.graphjs (dep_tree path mode) in
   Output.dep_tree env.absolute_dependency_paths w dt;
   Ok dt
 
 let run (env : Options.env) (w : Workspace.t) (input : Fpath.t) :
-    Dependency_tree.t Exec.status =
+    Dependency_tree.t Exec.result =
   let* dt = generate_dep_tree env w MultiFile input in
   Output.main env.absolute_dependency_paths w dt;
   Ok dt
 
-let outcome (result : Dependency_tree.t Exec.status) : Bulk.Instance.outcome =
+let outcome (result : Dependency_tree.t Exec.result) : Bulk.Instance.outcome =
   match result with
   | Ok _ -> Success
   | Error (`DepTree _) -> Failure
@@ -63,7 +63,7 @@ let interface (env : Options.env) : (module Bulk.CmdInterface) =
     let outcome = outcome
   end )
 
-let main (opts : Options.t) () : unit Exec.status =
+let main (opts : Options.t) () : unit Exec.result =
   let ext = Some "json" in
   let w = Workspace.create ~default:(`Single ext) opts.inputs opts.output in
   let* _ = Workspace.prepare w in

--- a/src/client/cmd_dependencies.ml
+++ b/src/client/cmd_dependencies.ml
@@ -33,12 +33,15 @@ module Output = struct
     | _ -> ()
 end
 
-let dep_tree (path : Fpath.t) (mode : Analysis_mode.t) () : Dependency_tree.t =
-  Dependency_tree.generate mode path
+module Graphjs = struct
+  let dep_tree (mode : Analysis_mode.t) (path : Fpath.t) :
+      Dependency_tree.t Exec.result =
+    Exec.graphjs (fun () -> Dependency_tree.generate mode path)
+end
 
 let generate_dep_tree (env : Options.env) (w : Workspace.t)
     (mode : Analysis_mode.t) (path : Fpath.t) : Dependency_tree.t Exec.result =
-  let* dt = Exec.graphjs (dep_tree path mode) in
+  let* dt = Graphjs.dep_tree mode path in
   Output.dep_tree env.absolute_dependency_paths w dt;
   Ok dt
 

--- a/src/client/cmd_mdg.ml
+++ b/src/client/cmd_mdg.ml
@@ -147,7 +147,7 @@ let build_program_mdgs (env : Options.env) (w : Workspace.t)
     (dt : Dependency_tree.t) (builder : State.t) (prog : 'm Prog.t) :
     (Fpath.t * Mdg.t) Exec.result list =
   let export_env = export_env env in
-  Fun.flip Dependency_tree.bottom_up_visit dt (fun (path, mrel) ->
+  Fun.flip Dependency_tree.visit_list dt (fun (path, mrel) ->
       let file = Prog.find prog path in
       let* mdg = Exec.graphjs (mdg_builder builder file) in
       let w' = Workspace.mdg env w mrel false in

--- a/src/client/cmd_parse.ml
+++ b/src/client/cmd_parse.ml
@@ -75,7 +75,7 @@ let normalizer_env (env : Options.env) : Normalizer.Env.t =
   }
 
 let normalize_program_modules (normalizer : Normalizer.Ctx.t) (w : Workspace.t)
-    (dt : Dependency_tree.t) : (Fpath.t * 'm File.t) Exec.status list =
+    (dt : Dependency_tree.t) : (Fpath.t * 'm File.t) Exec.result list =
   Fun.flip Dependency_tree.bottom_up_visit dt (fun (path, mrel) ->
       Output.source_file w path mrel;
       let* js_file = Exec.graphjs (js_parser path mrel) in
@@ -84,7 +84,7 @@ let normalize_program_modules (normalizer : Normalizer.Ctx.t) (w : Workspace.t)
       Ok (path, normalized_file) )
 
 let run (env : Options.env) (w : Workspace.t) (input : Fpath.t) :
-    (Dependency_tree.t * 'm Prog.t) Exec.status =
+    (Dependency_tree.t * 'm Prog.t) Exec.result =
   let* dt = Cmd_dependencies.generate_dep_tree env.deps_env w env.mode input in
   Identifier.reset_generator ();
   let normalizer_env = normalizer_env env in
@@ -94,7 +94,7 @@ let run (env : Options.env) (w : Workspace.t) (input : Fpath.t) :
   Output.main w prog;
   Ok (dt, prog)
 
-let outcome (result : (Dependency_tree.t * 'm Prog.t) Exec.status) :
+let outcome (result : (Dependency_tree.t * 'm Prog.t) Exec.result) :
     Bulk.Instance.outcome =
   match result with
   | Ok _ -> Success
@@ -111,7 +111,7 @@ let interface (env : Options.env) : (module Bulk.CmdInterface) =
     let outcome = outcome
   end )
 
-let main (opts : Options.t) () : unit Exec.status =
+let main (opts : Options.t) () : unit Exec.result =
   let w = Workspace.create ~default:`Bundle opts.inputs opts.output in
   let* _ = Workspace.prepare w in
   let* inputs = Bulk.InputTree.generate opts.inputs in

--- a/src/client/utils/exec.ml
+++ b/src/client/utils/exec.ml
@@ -9,7 +9,7 @@ type error =
   | `ExportMDG of Fmt.t -> unit
   ]
 
-type 'a status = ('a, error) Result.t
+type 'a result = ('a, error) Result.t
 
 let pp_err (ppf : Fmt.t) (err : error) : unit =
   match err with
@@ -22,24 +22,24 @@ let pp_err (ppf : Fmt.t) (err : error) : unit =
 
 let log_err (err : error) : unit = Log.stderr "%a" pp_err err
 
-let exn (err : error) : 'a status =
+let exn (err : error) : 'a result =
   log_err err;
   Error err
 
-let error (fmt : ('b, Fmt.t, unit, 'a status) format4) : 'b =
+let error (fmt : ('b, Fmt.t, unit, 'a result) format4) : 'b =
   Fmt.kdly (fun acc -> exn (`Generic acc)) fmt
 
-let fail (fmt : ('b, Fmt.t, unit, 'a status) format4) : 'b =
+let fail (fmt : ('b, Fmt.t, unit, 'a result) format4) : 'b =
   Fmt.kdly (fun acc -> exn (`Failure acc)) fmt
 
 let timeout () : 'b = exn `Timeout
 
-let bos (res : ('a, [< `Msg of string ]) result) : 'a status =
+let bos (res : ('a, [< `Msg of string ]) Result.t) : 'a result =
   match res with
   | Ok _ as res' -> res'
   | Error (`Msg err) -> exn (`Generic (Fmt.dly "%s" err))
 
-let graphjs (exec_f : unit -> 'a) : 'a status =
+let graphjs (exec_f : unit -> 'a) : 'a result =
   try Ok (exec_f ()) with
   | Graphjs_parser.Dependency_tree.Exn fmt -> exn (`DepTree fmt)
   | Graphjs_parser.Flow_parser.Exn fmt -> exn (`ParseJS fmt)

--- a/src/client/utils/fs.ml
+++ b/src/client/utils/fs.ml
@@ -29,35 +29,35 @@ module Parser = struct
   let valid_fpath = Fun.(parse Bos.OS.Path.exists "Path" << fix_dir << v, pp)
 end
 
-let handle_error ~(default : 'a) (f : t -> 'a Exec.status) (path : t) : 'a =
+let handle_error ~(default : 'a) (f : t -> 'a Exec.result) (path : t) : 'a =
   match f path with
   | Ok v -> v
   | Error err ->
     Log.warn "Unable to output to \"%a\".@\n%a" pp path Exec.pp_err err;
     default
 
-let mkdir (path : t) : unit Exec.status =
+let mkdir (path : t) : unit Exec.result =
   let path' = if is_dir_path path then path else parent path in
   Result.map (fun _ -> ()) (Exec.bos (Bos.OS.Dir.create path'))
 
-let delete ?(recurse : bool = false) (path : t) : unit Exec.status =
+let delete ?(recurse : bool = false) (path : t) : unit Exec.result =
   if is_dir_path path then
     Result.map (fun _ -> ()) (Exec.bos (Bos.OS.Dir.delete ~recurse path))
   else Result.map (fun _ -> ()) (Exec.bos (Bos.OS.File.delete path))
 
-let exists (path : t) : bool Exec.status =
+let exists (path : t) : bool Exec.result =
   if is_dir_path path then Exec.bos (Bos.OS.Dir.exists path)
   else Exec.bos (Bos.OS.File.exists path)
 
-let copy (path : t) (src : t) : unit Exec.status =
+let copy (path : t) (src : t) : unit Exec.result =
   let open Result in
   let* data = Exec.bos (Bos.OS.File.read src) in
   Exec.bos (Bos.OS.File.write path data)
 
-let output (path : t) (pp_v : Fmt.t -> 'a -> unit) (v : 'a) : unit Exec.status =
+let output (path : t) (pp_v : Fmt.t -> 'a -> unit) (v : 'a) : unit Exec.result =
   Exec.bos (Bos.OS.File.writef path "%a" pp_v v)
 
-let write (path : t) (fmt : ('a, Fmt.t, unit, 'b) format4) : unit Exec.status =
+let write (path : t) (fmt : ('a, Fmt.t, unit, 'b) format4) : unit Exec.result =
   Exec.bos (Bos.OS.File.writef path fmt)
 
 let mkdir_noerr (path : t) : unit = handle_error ~default:() mkdir path

--- a/src/client/utils/workspace.ml
+++ b/src/client/utils/workspace.ml
@@ -70,8 +70,8 @@ let ( // ) (w : t) (rel : Fpath.t) : t = map Fpath.(fun path -> path // rel) w
 let ( + ) (w : t) (ext : string) : t = map Fpath.(fun path -> path + ext) w
 let ( -+ ) (w : t) (ext : string) : t = map Fpath.(fun path -> path -+ ext) w
 
-let execute (p : perm) (w : t) (f : Fpath.t -> 'a Exec.status) :
-    unit Exec.status =
+let execute (p : perm) (w : t) (f : Fpath.t -> 'a Exec.result) :
+    unit Exec.result =
   match (p, w.path) with
   | (Main, Single path) | (Main, Bundle path) | (Side, Bundle path) ->
     Result.map ignore (f path)
@@ -88,30 +88,30 @@ let log (w : t) (fmt : ('a, Fmt.t, unit, unit) format4) : 'a =
   | Main when not Log.Config.(!log_verbose) -> Log.stdout fmt
   | _ -> Log.ignore fmt
 
-let mkdir (p : perm) (w : t) : unit Exec.status = execute p w Fs.mkdir
+let mkdir (p : perm) (w : t) : unit Exec.result = execute p w Fs.mkdir
 let mkdir_noerr (p : perm) (w : t) : unit = execute_noerr p w Fs.mkdir_noerr
 
-let copy (p : perm) (w : t) (src : Fpath.t) : unit Exec.status =
+let copy (p : perm) (w : t) (src : Fpath.t) : unit Exec.result =
   execute p w (Fun.flip Fs.copy src)
 
 let copy_noerr (p : perm) (w : t) (src : Fpath.t) : unit =
   execute_noerr p w (Fun.flip Fs.copy_noerr src)
 
 let output (p : perm) (w : t) (pp : Fmt.t -> 'a -> unit) (v : 'a) :
-    unit Exec.status =
+    unit Exec.result =
   execute p w (Fun.flip2 Fs.output pp v)
 
 let output_noerr (p : perm) (w : t) (pp : Fmt.t -> 'a -> unit) (v : 'a) : unit =
   execute_noerr p w (Fun.flip2 Fs.output_noerr pp v)
 
 let write (p : perm) (w : t) (fmt : ('a, Fmt.t, unit, 'b) format4) :
-    unit Exec.status =
+    unit Exec.result =
   execute p w (Fun.flip Fs.write fmt)
 
 let write_noerr (p : perm) (w : t) (fm : ('a, Fmt.t, unit, 'b) format4) : unit =
   execute_noerr p w (Fun.flip Fs.write_noerr fm)
 
-let clean (w : t) : unit Exec.status =
+let clean (w : t) : unit Exec.result =
   let open Result in
   let create_dir_template dir_path manifest_path =
     let* _ = Fs.mkdir dir_path in
@@ -144,7 +144,7 @@ let clean (w : t) : unit Exec.status =
       else error_dir dir_path
     else create_dir_template dir_path manifest_path
 
-let prepare (w : t) : unit Exec.status =
+let prepare (w : t) : unit Exec.result =
   Fun.flip Result.map (clean w) (fun res ->
       Log.info "Workspace \"%a\" generated successfully." pp_path w;
       res )

--- a/src/graphjs.ml
+++ b/src/graphjs.ml
@@ -2,7 +2,7 @@ open Graphjs_base
 open Graphjs_client
 open Cmdliner
 
-type status = (unit Exec.status Cmd.eval_ok, Cmd.eval_error) Result.t
+type status = (unit Exec.result Cmd.eval_ok, Cmd.eval_error) Result.t
 
 let set_copts (colorless : bool) (lvl : Enums.DebugLvl.t) (verbose : bool)
     (override' : bool) : unit =


### PR DESCRIPTION
Before this PR, the logic behind each component (dependencies, parser, MDG builder...) was described in the command, along with calls to functions that would output the information being computed. After these changes, this logic is described in the component itself, which also receives callbacks to output the generated information.

*Note:* The `mdg` module was not implemented because it will have to change drastically to incorportate the new merging mechanism