### PR TITLE
Implement package sinks in the mdg builder

### DIFF
--- a/src/analyzer/domain/vulnerability.ml
+++ b/src/analyzer/domain/vulnerability.ml
@@ -12,9 +12,8 @@ let create (kind : string) (sink : string) (line : int) : t =
   { kind; sink; line }
 
 let make (sink : Tainted.sink) (node : Node.t) : t =
-  let name = Tainted.(name !sink) in
-  let kind = Sink_kind.str (Tainted.kind sink) in
-  create kind name node.at.lpos.line
+  let kind = Sink_kind.str sink.kind in
+  create kind sink.name node.at.lpos.line
 
 let update (vuln : t) (node : Node.t) : t =
   { vuln with line = node.at.lpos.line }

--- a/src/mdg/domain/npm.ml
+++ b/src/mdg/domain/npm.ml
@@ -1,0 +1,89 @@
+open Graphjs_base
+open Graphjs_share
+
+module Template = struct
+  type el =
+    | Source of Tainted.source
+    | Sink of Tainted.sink
+
+  let pp_el (ppf : Fmt.t) (el : el) : unit =
+    match el with
+    | Source source -> Tainted.pp_source ppf source
+    | Sink sink -> Tainted.pp_sink ppf sink
+
+  type t =
+    { sources : Tainted.source list
+    ; sinks : Tainted.sink list
+    }
+
+  let create () : t = { sources = []; sinks = [] }
+
+  let add_source (source : Tainted.source) (template : t) : t =
+    { template with sources = source :: template.sources }
+
+  let add_sink (sink : Tainted.sink) (template : t) : t =
+    { template with sinks = sink :: template.sinks }
+
+  let to_list (template : t) : el list =
+    List.map (fun source -> Source source) template.sources
+    @ List.map (fun sink -> Sink sink) template.sinks
+
+  let pp (ppf : Fmt.t) (template : t) : unit =
+    Fmt.fmt ppf "@\n@[<v 2>  %a@]" Fmt.(pp_lst !>"@\n" pp_el) (to_list template)
+
+  let str (template : t) : string = Fmt.str "%a" pp template
+end
+
+type package =
+  | Built of Node.t
+  | Template of Template.t
+
+type t = (string, package) Hashtbl.t
+
+let set_source (npm : t) (package_source : Taint_config.package_source) : unit =
+  Fun.flip List.iter package_source.packages (fun package ->
+      let source = Tainted.package_source package.package package_source in
+      match Hashtbl.find_opt npm package.package with
+      | None ->
+        let template = Template.create () |> Template.add_source source in
+        Hashtbl.replace npm package.package (Template template)
+      | Some (Template template) ->
+        let template' = Template.add_source source template in
+        Hashtbl.replace npm package.package (Template template')
+      | Some (Built _) ->
+        Log.fail "unexpected built npm package during initialization" )
+
+let set_sink (npm : t) (package_sink : Taint_config.package_sink) : unit =
+  Fun.flip List.iter package_sink.packages (fun package ->
+      let sink = Tainted.package_sink package.package package_sink in
+      match Hashtbl.find_opt npm package.package with
+      | None ->
+        let template = Template.create () |> Template.add_sink sink in
+        Hashtbl.replace npm package.package (Template template)
+      | Some (Template template) ->
+        let template' = Template.add_sink sink template in
+        Hashtbl.replace npm package.package (Template template')
+      | Some (Built _) ->
+        Log.fail "unexpected built npm package during initialization" )
+
+let create (tconf : Taint_config.t) : t =
+  let npm = Hashtbl.create Config.(!dflt_htbl_sz) in
+  List.iter (set_source npm) tconf.package_sources;
+  List.iter (set_sink npm) tconf.package_sinks;
+  npm
+
+let pp_package (ppf : Fmt.t) (package : package) : unit =
+  match package with
+  | Built node -> Node.pp ppf node
+  | Template template -> Template.pp ppf template
+
+let pp (ppf : Fmt.t) (npm : t) : unit =
+  let pp_pkg ppf (name, package) =
+    Fmt.fmt ppf "%S: %a" name pp_package package in
+  Fmt.(pp_htbl !>"@\n") pp_pkg ppf npm
+
+let str (npm : t) : string = Fmt.str "%a" pp npm
+
+let resolve (_npm : t) (_mdg : Mdg.t) (package : string) : Node.t option =
+  Log.debug "Resolving package %S..." package;
+  None

--- a/src/mdg/domain/npm.ml
+++ b/src/mdg/domain/npm.ml
@@ -93,8 +93,9 @@ let build_package_template (mdg : Mdg.t) (template : Template.t) : Node.t =
   let l_npm = Node.create_module template.name in
   Mdg.add_node mdg l_npm;
   Fun.flip List.iter template.sinks (fun sink ->
+      let at = Region.default () in
       let prop = Property.Static sink.name in
-      let l_sink = Node.create_taint_sink sink None (Region.default ()) in
+      let l_sink = Node.create_taint_sink sink (Some l_npm) at in
       Mdg.add_node mdg l_sink;
       Mdg.add_edge mdg (Edge.create_property prop l_npm l_sink) );
   l_npm

--- a/src/mdg/domain/state.ml
+++ b/src/mdg/domain/state.ml
@@ -34,6 +34,7 @@ end
 
 type t =
   { env : Env.t
+  ; npm : Npm.t
   ; mdg : Mdg.t
   ; store : Store.t
   ; allocator : Node.t Allocator.t
@@ -53,9 +54,10 @@ and stmt_ctx =
   | General
   | PropUpd
 
-let create (env' : Env.t) (prog : 'm Prog.t) : t =
+let create (env' : Env.t) (npm' : Npm.t) (prog : 'm Prog.t) : t =
   let store' = Store.create () in
   { env = env'
+  ; npm = npm'
   ; mdg = Mdg.create ()
   ; store = store'
   ; allocator = Allocator.create Config.(!dflt_htbl_sz)

--- a/src/mdg/dune
+++ b/src/mdg/dune
@@ -9,6 +9,7 @@
   tainted
   node
   edge
+  npm
   mdg
   store
   allocator

--- a/src/mdg/export/svg_exporter.ml
+++ b/src/mdg/export/svg_exporter.ml
@@ -52,7 +52,7 @@ module Dot = struct
     | Return name -> Fmt.str "%s" (String.escaped name)
     | Module name -> Fmt.str "%s" (String.escaped name)
     | TaintSource -> Fmt.str "{ Taint Source }"
-    | TaintSink sink -> Fmt.str "sink %s" Tainted.(name !sink)
+    | TaintSink sink -> Fmt.str "sink %s" (String.escaped sink.name)
 
   let edge_label (edge : Edge.t) : string =
     match edge.kind with

--- a/src/mdg/graph/node.ml
+++ b/src/mdg/graph/node.ml
@@ -49,8 +49,7 @@ let pp (ppf : Fmt.t) (node : t) : unit =
   | Return name -> Fmt.fmt ppf "%s[%a]" name Location.pp node.loc
   | Module name -> Fmt.fmt ppf "[[module]] %s[%a]" name Location.pp node.loc
   | TaintSource -> Fmt.pp_str ppf "[[taint]]"
-  | TaintSink sink ->
-    Fmt.fmt ppf "%s[%a]" Tainted.(name !sink) Location.pp node.loc
+  | TaintSink sink -> Fmt.fmt ppf "%s[%a]" sink.name Location.pp node.loc
 
 let str (node : t) : string = Fmt.str "%a" pp node
 
@@ -151,7 +150,7 @@ let name (node : t) : string =
   | Parameter name -> name
   | Call name -> name
   | Return name -> name
-  | TaintSink sink -> Tainted.(name !sink)
+  | TaintSink sink -> sink.name
   | _ -> Log.fail "unexpected node '%a' without name" pp node
 
 let sink (node : t) : Tainted.sink =

--- a/src/mdg/graph/node.ml
+++ b/src/mdg/graph/node.ml
@@ -49,7 +49,7 @@ let pp (ppf : Fmt.t) (node : t) : unit =
   | Return name -> Fmt.fmt ppf "%s[%a]" name Location.pp node.loc
   | Module name -> Fmt.fmt ppf "[[module]] %s[%a]" name Location.pp node.loc
   | TaintSource -> Fmt.pp_str ppf "[[taint]]"
-  | TaintSink sink -> Fmt.fmt ppf "%s[%a]" sink.name Location.pp node.loc
+  | TaintSink sink -> Fmt.fmt ppf "[[sink]] %s[%a]" sink.name Location.pp node.loc
 
 let str (node : t) : string = Fmt.str "%a" pp node
 

--- a/src/mdg/graph/tainted.ml
+++ b/src/mdg/graph/tainted.ml
@@ -2,12 +2,14 @@ open Graphjs_base
 open Graphjs_share
 
 type source =
-  { name : string
+  { mrel : string option
+  ; name : string
   ; args : int list
   }
 
 type sink =
-  { name : string
+  { mrel : string option
+  ; name : string
   ; kind : Sink_kind.t
   ; args : int list
   }
@@ -19,17 +21,17 @@ type t =
 let package_source (name : string) (source : Taint_config.package_source) :
     source =
   let package = Taint_config.find_package name source.packages in
-  { name = source.source; args = package.args }
+  { mrel = Some name; name = source.source; args = package.args }
 
 let package_sink (name : string) (sink : Taint_config.package_sink) : sink =
   let package = Taint_config.find_package name sink.packages in
-  { name = sink.sink; kind = sink.kind; args = package.args }
+  { mrel = Some name; name = sink.sink; kind = sink.kind; args = package.args }
 
 let function_sink (sink : Taint_config.function_sink) : sink =
-  { name = sink.sink; kind = sink.kind; args = sink.args }
+  { mrel = None; name = sink.sink; kind = sink.kind; args = sink.args }
 
 let new_sink (sink : Taint_config.new_sink) : sink =
-  { name = sink.sink; kind = sink.kind; args = sink.args }
+  { mrel = None; name = sink.sink; kind = sink.kind; args = sink.args }
 
 let pp_args (ppf : Fmt.t) (args : int list) : unit =
   Fmt.(pp_lst !>", " pp_int) ppf args

--- a/src/mdg/jslib.ml
+++ b/src/mdg/jslib.ml
@@ -44,11 +44,11 @@ module CallInterceptor = struct
     | _ -> None
 
   let process_module (cb_build_file : cb_build_file) (state : State.t)
-      (path : Fpath.t) : Node.Set.t =
+      (retn_name : string) (path : Fpath.t) : Node.Set.t =
     match Pcontext.file state.pcontext path with
     | None ->
       Log.warn "TODO: check for npm modules";
-      Node.Set.empty
+      Store.find state.store retn_name
     | Some file when file.built ->
       exported_object ~mrel:file.file.mrel state.mdg
     | Some file ->
@@ -60,7 +60,7 @@ module CallInterceptor = struct
     match get_module_path state ls_args with
     | None -> state
     | Some path ->
-      let ls_exports = process_module cb_build_file state path in
+      let ls_exports = process_module cb_build_file state retn_name path in
       Store.replace state.store retn_name ls_exports;
       state
 end

--- a/src/mdg/jslib.ml
+++ b/src/mdg/jslib.ml
@@ -68,17 +68,16 @@ end
 let add_tainted_sink (make_generic_sink_f : 'a -> Tainted.sink)
     (state : State.t) (generic_sink : 'a) : State.t =
   let sink = make_generic_sink_f generic_sink in
-  let name = Tainted.(name !sink) in
-  let name_jslib = NameResolver.sink name in
+  let name_jslib = NameResolver.sink sink.name in
   let l_sink = Node.create_taint_sink sink None (Region.default ()) in
   Mdg.add_jslib state.mdg name_jslib l_sink;
-  Store.replace state.store name (Node.Set.singleton l_sink);
+  Store.replace state.store sink.name (Node.Set.singleton l_sink);
   state
 
 let initialize_tainted_sinks (state : State.t) (tconf : Taint_config.t) :
     State.t =
-  let make_fun_sink_f = add_tainted_sink (fun sink -> `FunctionSink sink) in
-  (* let make_new_sink_f = add_tainted_sink (fun sink -> `NewSink sink) in *)
+  let make_fun_sink_f = add_tainted_sink Tainted.function_sink in
+  (* let make_new_sink_f = add_tainted_sink Tainted.new_sink in *)
   let state' = List.fold_left make_fun_sink_f state tconf.function_sinks in
   (* let state'' = List.fold_left make_new_sink_f state' tconf.new_sinks in *)
   state'

--- a/src/mdg/jslib.ml
+++ b/src/mdg/jslib.ml
@@ -43,12 +43,18 @@ module CallInterceptor = struct
       | _ -> None )
     | _ -> None
 
+  let resolve_npm (state : State.t) (retn_name : string) (package : string) :
+      Node.Set.t =
+    match Npm.resolve state.npm state.mdg package with
+    | Some l_npm -> Node.Set.singleton l_npm
+    | None -> Store.find state.store retn_name
+
   let process_module (cb_build_file : cb_build_file) (state : State.t)
       (retn_name : string) (path : Fpath.t) : Node.Set.t =
     match Pcontext.file state.pcontext path with
     | None ->
-      Log.warn "TODO: check for npm modules";
-      Store.find state.store retn_name
+      let package = Fpath.filename path in
+      resolve_npm state retn_name package
     | Some file when file.built ->
       exported_object ~mrel:file.file.mrel state.mdg
     | Some file ->

--- a/src/share/taint_config.ml
+++ b/src/share/taint_config.ml
@@ -52,6 +52,9 @@ let default =
     } in
   fun () -> dflt
 
+let find_package (name : string) (packages : package list) : package =
+  List.find (fun package -> String.equal name package.package) packages
+
 let pp_indent (pp_v : Fmt.t -> 'a -> unit) (ppf : Fmt.t) (vs : 'a list) : unit =
   if List.length vs == 0 then ()
   else Fmt.fmt ppf "@\n@[<v 2>  %a@]" Fmt.(pp_lst !>"@\n" pp_v) vs

--- a/test/mdg_builder/require.t/run.t
+++ b/test/mdg_builder/require.t/run.t
@@ -1,6 +1,4 @@
   $ graphjs mdg --no-export --mode singlefile main.js
-  [warn] TODO: check for npm modules
-  [warn] TODO: check for npm modules
   require[#8] -
   './foo.js'[#11] --< Arg(1) >--> require(...)[#12]
   require(...)[#12] --< Call >--> require[#8]

--- a/test/mdg_builder/require.t/run.t
+++ b/test/mdg_builder/require.t/run.t
@@ -5,19 +5,39 @@
   './foo.js'[#11] --< Arg(1) >--> require(...)[#12]
   require(...)[#12] --< Call >--> require[#8]
   require(...)[#12] --< D >--> foo[#13]
-  foo[#13] -
+  foo[#13] --< P(obj) >--> foo.obj[#17]
+  foo[#13] --< P(foo) >--> foo.foo[#18]
+  foo[#13] --< Arg(0) >--> foo.foo(...)[#19]
   './deps/bar.js'[#14] --< Arg(1) >--> require(...)[#15]
   require(...)[#15] --< Call >--> require[#8]
   require(...)[#15] --< D >--> bar[#16]
-  bar[#16] -
-  foo.foo(...)[#17] --< D >--> $v2[#18]
-  $v2[#18] -
-  $v3.p(...)[#19] --< D >--> $v5[#20]
-  $v5[#20] -
-  $v7.q(...)[#21] --< D >--> $v8[#22]
-  $v8[#22] -
-  bar.bar4(...)[#23] --< D >--> $v9[#24]
-  $v9[#24] -
+  bar[#16] --< P(bar1) >--> bar.bar1[#21]
+  bar[#16] --< P(bar3) >--> bar.bar3[#25]
+  bar[#16] --< P(bar4) >--> bar.bar4[#30]
+  bar[#16] --< Arg(0) >--> bar.bar4(...)[#31]
+  foo.obj[#17] --< Arg(1) >--> foo.foo(...)[#19]
+  foo.obj[#17] --< Arg(1) >--> bar.bar1.p(...)[#23]
+  foo.foo[#18] -
+  foo.foo(...)[#19] --< Call >--> foo.foo[#18]
+  foo.foo(...)[#19] --< D >--> $v2[#20]
+  $v2[#20] -
+  bar.bar1[#21] --< P(p) >--> bar.bar1.p[#22]
+  bar.bar1[#21] --< Arg(0) >--> bar.bar1.p(...)[#23]
+  bar.bar1.p[#22] -
+  bar.bar1.p(...)[#23] --< Call >--> bar.bar1.p[#22]
+  bar.bar1.p(...)[#23] --< D >--> $v5[#24]
+  $v5[#24] -
+  bar.bar3[#25] --< P(p) >--> bar.bar3.p[#26]
+  bar.bar3.p[#26] --< P(q) >--> bar.bar3.p.q[#27]
+  bar.bar3.p[#26] --< Arg(0) >--> bar.bar3.p.q(...)[#28]
+  bar.bar3.p.q[#27] -
+  bar.bar3.p.q(...)[#28] --< Call >--> bar.bar3.p.q[#27]
+  bar.bar3.p.q(...)[#28] --< D >--> $v8[#29]
+  $v8[#29] -
+  bar.bar4[#30] -
+  bar.bar4(...)[#31] --< Call >--> bar.bar4[#30]
+  bar.bar4(...)[#31] --< D >--> $v9[#32]
+  $v9[#32] -
 
   $ graphjs mdg --no-export --mode multifile main.js
   require[#8] -

--- a/test/mdg_builder/sink.t/run.t
+++ b/test/mdg_builder/sink.t/run.t
@@ -1,14 +1,14 @@
   $ graphjs mdg --no-export eval.js
-  eval[#2] -
+  [[sink]] eval[#2] -
   foo[#11] --< Param(0) >--> this[#12]
   foo[#11] --< Param(1) >--> x1[#13]
   this[#12] -
   x1[#13] --< Arg(1) >--> eval(...)[#14]
-  eval(...)[#14] --< Call >--> eval[#2]
+  eval(...)[#14] --< Call >--> [[sink]] eval[#2]
   eval(...)[#14] --< D >--> $v1[#15]
   $v1[#15] -
   10[#16] --< Arg(1) >--> eval(...)[#17]
-  eval(...)[#17] --< Call >--> eval[#2]
+  eval(...)[#17] --< Call >--> [[sink]] eval[#2]
   eval(...)[#17] --< D >--> $v2[#18]
   $v2[#18] -
 


### PR DESCRIPTION
This PR adds package sinks to the mdg builder. When an npm module is required, the builder generates a graph with the sinks of the package based on the tainted configuration file.