### PR TITLE
Support ocaml 5.3.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
           - ubuntu-latest
           - macos-latest
         ocaml-compiler:
-          - "5.2"
+          - "5.3"
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout

--- a/dune-project
+++ b/dune-project
@@ -31,7 +31,7 @@
   dune
   dune-site
   (flow_parser
-   (= 0.246.0))
+   (>= "0.268.0"))
   (ocaml
    (>= "5.2.0"))
   ocamlformat

--- a/graphjs.opam
+++ b/graphjs.opam
@@ -22,7 +22,7 @@ depends: [
   "conf-npm"
   "dune" {>= "3.2"}
   "dune-site"
-  "flow_parser" {= "0.246.0"}
+  "flow_parser" {>= "0.268.0"}
   "ocaml" {>= "5.2.0"}
   "ocamlformat"
   "ocamlgraph"

--- a/src/base/font.ml
+++ b/src/base/font.ml
@@ -24,7 +24,7 @@ module Attr = struct
     | `White
     ]
 
-  type effect =
+  type effect_ =
     [ `Disable
     | `Faint
     | `Blink
@@ -43,7 +43,7 @@ module Attr = struct
     [ `Reset
     | `Foreground of color
     | `Background of color
-    | `Effect of effect
+    | `Effect of effect_
     | `Style of style
     ]
 
@@ -78,7 +78,7 @@ module Attr = struct
     | `Reset -> 0
     | `Foreground fg -> to_code fg
     | `Background bg -> to_code bg + 10
-    | `Effect effect -> to_code effect
+    | `Effect effect_ -> to_code effect_
     | `Style style -> to_code style
 end
 
@@ -91,19 +91,21 @@ open struct
   let mk_background (bg : Attr.color option) (font : t) : t =
     Option.fold ~none:font ~some:(fun bg -> `Background bg :: font) bg
 
-  let mk_effect (effect : Attr.effect option) (font : t) : t =
-    Option.fold ~none:font ~some:(fun effect' -> `Effect effect' :: font) effect
+  let mk_effect (effect_ : Attr.effect_ option) (font : t) : t =
+    Option.fold ~none:font
+      ~some:(fun effect' -> `Effect effect' :: font)
+      effect_
 
   let mk_style ((style, on) : Attr.style * bool option) (font : t) : t =
     let style_f = function true -> `Style style :: font | false -> font in
     Option.fold ~none:font ~some:style_f on
 
   let mk_font (fg : Attr.color option) (bg : Attr.color option)
-      (effect : Attr.effect option) (bold : bool option) (italic : bool option)
+      (effect_ : Attr.effect_ option) (bold : bool option) (italic : bool option)
       (underline : bool option) (strike : bool option) : t =
     mk_foreground fg []
     |> mk_background bg
-    |> mk_effect effect
+    |> mk_effect effect_
     |> mk_style (`Bold, bold)
     |> mk_style (`Italic, italic)
     |> mk_style (`Underline, underline)
@@ -118,8 +120,8 @@ let get_foreground (font : t) : Attr.color option =
 let get_background (font : t) : Attr.color option =
   List.find_map (function `Background bg -> Some bg | _ -> None) font
 
-let get_effect (font : t) : Attr.effect option =
-  List.find_map (function `Effect effect -> Some effect | _ -> None) font
+let get_effect (font : t) : Attr.effect_ option =
+  List.find_map (function `Effect effect_ -> Some effect_ | _ -> None) font
 
 let get_style (style : Attr.style) (font : t) : bool option =
   Fun.flip List.find_map font (function
@@ -127,21 +129,21 @@ let get_style (style : Attr.style) (font : t) : bool option =
     | _ -> None )
 
 let create ?(fg : Attr.color option) ?(bg : Attr.color option)
-    ?(effect : Attr.effect option) ?(bold : bool option) ?(italic : bool option)
+    ?(effect_ : Attr.effect_ option) ?(bold : bool option) ?(italic : bool option)
     ?(underline : bool option) ?(strike : bool option) () : t =
-  mk_font fg bg effect bold italic underline strike
+  mk_font fg bg effect_ bold italic underline strike
 
 let update ?(fg : Attr.color option) ?(bg : Attr.color option)
-    ?(effect : Attr.effect option) ?(bold : bool option) ?(italic : bool option)
+    ?(effect_ : Attr.effect_ option) ?(bold : bool option) ?(italic : bool option)
     ?(underline : bool option) ?(strike : bool option) (font : t) : t =
   let fg = Option.map_none ~value:(get_foreground font) fg in
   let bg = Option.map_none ~value:(get_background font) bg in
-  let effect = Option.map_none ~value:(get_effect font) effect in
+  let effect_ = Option.map_none ~value:(get_effect font) effect_ in
   let bold = Option.map_none ~value:(get_style `Bold font) bold in
   let italic = Option.map_none ~value:(get_style `Italic font) italic in
   let underline = Option.map_none ~value:(get_style `Underline font) underline in
   let strike = Option.map_none ~value:(get_style `Strike font) strike in
-  mk_font fg bg effect bold italic underline strike
+  mk_font fg bg effect_ bold italic underline strike
 
 let pp_font (ppf : Fmt.t) (font : t) : unit =
   let pp_attr ppf attr = Fmt.pp_int ppf (Attr.code attr) in

--- a/src/client/utils/bulk.ml
+++ b/src/client/utils/bulk.ml
@@ -3,7 +3,7 @@ open Graphjs_base
 module Config = struct
   include Config
 
-  let time_font_f (font : Font.t) : Font.t = Font.update font ~effect_:`Faint
+  let time_font_f (font : Font.t) : Font.t = Font.update font ~filter:`Faint
   let main_font = constant (Font.create ~fg:`White ())
   let path_font = constant (Font.create ~fg:`DarkGray ())
   let success_font = constant (Font.create ~fg:`LightGreen ())

--- a/src/client/utils/bulk.ml
+++ b/src/client/utils/bulk.ml
@@ -3,7 +3,7 @@ open Graphjs_base
 module Config = struct
   include Config
 
-  let time_font_f (font : Font.t) : Font.t = Font.update font ~effect:`Faint
+  let time_font_f (font : Font.t) : Font.t = Font.update font ~effect_:`Faint
   let main_font = constant (Font.create ~fg:`White ())
   let path_font = constant (Font.create ~fg:`DarkGray ())
   let success_font = constant (Font.create ~fg:`LightGreen ())

--- a/src/parser/normalizer.ml
+++ b/src/parser/normalizer.ml
@@ -983,6 +983,7 @@ and normalize_expr (ctx : Ctx.t) : (Loc.t, Loc.t) Flow.Expression.t -> n_expr =
  | (loc, ArrowFunction func) -> normalize_function_expression ctx loc func
  | (loc, Class class') -> normalize_class_expression ctx loc class'
  | (loc, Import import) -> normalize_dynamic_import ctx loc import
+ | (_, Match _) -> Log.fail "[not implemented]: Match statements"
  | (_, TypeCast _)
  | (_, TSSatisfies _)
  | (_, AsConstExpression _)
@@ -991,8 +992,7 @@ and normalize_expr (ctx : Ctx.t) : (Loc.t, Loc.t) Flow.Expression.t -> n_expr =
  | (_, JSXElement _) | (_, JSXFragment _) ->
    Log.fail "[not implemented]: React expressions"
  | (_, ModuleRefLiteral _) ->
-   Log.fail "[internal flow construct]: ModuleRefLiteral"
- | (_, Match _) -> Log.fail "[internal flow construct]: ModuleRefLiteral" )
+   Log.fail "[internal flow construct]: ModuleRefLiteral" )
 
 and normalize_expr_opt (ctx : Ctx.t)
     (expr : (Loc.t, Loc.t) Flow.Expression.t option) : stmt list * expr option =
@@ -1374,6 +1374,7 @@ and normalize_stmt (ctx : Ctx.t) : (Loc.t, Loc.t) Flow.Statement.t -> n_stmt =
   | (loc, ImportDeclaration import) -> normalize_import ctx loc import
   | (loc, ExportDefaultDeclaration exp) -> normalize_default_export ctx loc exp
   | (loc, ExportNamedDeclaration exp) -> normalize_named_export ctx loc exp
+  | (_, Match _) -> Log.fail "[not implemented]: Match statements"
   | (_, TypeAlias _)
   | (_, OpaqueType _)
   | (_, EnumDeclaration _)
@@ -1394,7 +1395,6 @@ and normalize_stmt (ctx : Ctx.t) : (Loc.t, Loc.t) Flow.Statement.t -> n_stmt =
     Log.fail "[not implemented]: TypeScript declaration statements"
   | (_, ComponentDeclaration _) ->
     Log.fail "[not implemented]: React statements"
-  | (_, Match _) -> Log.fail "[not implemented]: Match statements"
 
 and normalize_alias_wrapper (ctx : Ctx.t) (md : md) (wrapped_f : lval -> n_stmt)
     (n_left : lval) (alias : (Loc.t, Loc.t) Flow.Identifier.t option) : n_stmt =
@@ -1715,9 +1715,9 @@ and requires_expr_stmt (expr : (Loc.t, Loc.t) Flow.Expression.t) : bool =
   | (_, ArrowFunction _)
   | (_, Class _)
   | (_, Import _)
+  | (_, Match _)
   | (_, JSXElement _)
-  | (_, JSXFragment _)
-  | (_, Match _) ->
+  | (_, JSXFragment _) ->
     false
 
 let normalize_program (env : Env.t) (dt : Dependency_tree.t) : Region.t Prog.t =

--- a/src/parser/normalizer.ml
+++ b/src/parser/normalizer.ml
@@ -991,7 +991,8 @@ and normalize_expr (ctx : Ctx.t) : (Loc.t, Loc.t) Flow.Expression.t -> n_expr =
  | (_, JSXElement _) | (_, JSXFragment _) ->
    Log.fail "[not implemented]: React expressions"
  | (_, ModuleRefLiteral _) ->
-   Log.fail "[internal flow construct]: ModuleRefLiteral" )
+   Log.fail "[internal flow construct]: ModuleRefLiteral"
+ | (_, Match _) -> Log.fail "[internal flow construct]: ModuleRefLiteral" )
 
 and normalize_expr_opt (ctx : Ctx.t)
     (expr : (Loc.t, Loc.t) Flow.Expression.t option) : stmt list * expr option =
@@ -1305,10 +1306,10 @@ and normalize_named_export_spec (ctx : Ctx.t) (md : md) (n_src : string option)
     [ n_export_s ]
   | ExportSpecifiers specifiers ->
     Fun.flip List.map specifiers (function
-      | (_, { local; exported = None }) ->
+      | (_, { local; exported = None; _ }) ->
         let n_prop = normalize_identifier ctx local in
         ExportDecl.create_stmt (Property n_prop) n_src @> md
-      | (_, { local; exported = Some exported' }) ->
+      | (_, { local; exported = Some exported'; _ }) ->
         let n_id = normalize_identifier ctx local in
         let n_alias = normalize_identifier ctx exported' in
         ExportDecl.create_stmt (Alias (n_id, n_alias)) n_src @> md )
@@ -1393,6 +1394,7 @@ and normalize_stmt (ctx : Ctx.t) : (Loc.t, Loc.t) Flow.Statement.t -> n_stmt =
     Log.fail "[not implemented]: TypeScript declaration statements"
   | (_, ComponentDeclaration _) ->
     Log.fail "[not implemented]: React statements"
+  | (_, Match _) -> Log.fail "[not implemented]: Match statements"
 
 and normalize_alias_wrapper (ctx : Ctx.t) (md : md) (wrapped_f : lval -> n_stmt)
     (n_left : lval) (alias : (Loc.t, Loc.t) Flow.Identifier.t option) : n_stmt =
@@ -1714,7 +1716,8 @@ and requires_expr_stmt (expr : (Loc.t, Loc.t) Flow.Expression.t) : bool =
   | (_, Class _)
   | (_, Import _)
   | (_, JSXElement _)
-  | (_, JSXFragment _) ->
+  | (_, JSXFragment _)
+  | (_, Match _) ->
     false
 
 let normalize_program (env : Env.t) (dt : Dependency_tree.t) : Region.t Prog.t =


### PR DESCRIPTION
- Rename `effect` -> `effect_` because `effect` is a protected keyword in ocaml 5.3.0

- Use flow_parser version 0.268.0 which now supports ocaml 5.3.0