### PR TITLE
Add validation command for dataset packages

### DIFF
--- a/src/client/cmd_dependencies.ml
+++ b/src/client/cmd_dependencies.ml
@@ -28,21 +28,23 @@ module Graphjs = struct
 end
 
 module Output = struct
-  let main (abs : bool) (w : Workspace.t) (dt : Dependency_tree.t) : unit =
+  let dep_tree (abs : bool) (w : Workspace.t) (dt : Dependency_tree.t) : unit =
+    let w' = Workspace.(w / "dep_tree.json") in
     Log.info "Dependency tree \"%a\" generated successfully." Fpath.pp dt.path;
     Log.verbose "%a" (Dependency_tree.pp abs) dt;
-    Workspace.log w "%a@." (Dependency_tree.pp abs) dt;
+    Workspace.output_noerr Side w' (Dependency_tree.pp abs) dt
+
+  let main (abs : bool) (w : Workspace.t) (dt : Dependency_tree.t) : unit =
+    Workspace.log w "%a" (Dependency_tree.pp abs) dt;
     match w.path with
     | Single _ -> Workspace.output_noerr Main w (Dependency_tree.pp abs) dt
-    | Bundle _ ->
-      let w' = Workspace.(w / "dep_tree.json") in
-      Workspace.output_noerr Side w' (Dependency_tree.pp abs) dt
     | _ -> ()
 end
 
 let run (env : Options.env) (w : Workspace.t) (input : Fpath.t) :
     Dependency_tree.t Exec.result =
   let* dt = Graphjs.dep_tree env.multifile input in
+  Output.dep_tree env.absolute_dependency_paths w dt;
   Output.main env.absolute_dependency_paths w dt;
   Ok dt
 

--- a/src/client/cmd_dependencies.ml
+++ b/src/client/cmd_dependencies.ml
@@ -28,23 +28,21 @@ module Graphjs = struct
 end
 
 module Output = struct
-  let dep_tree (abs : bool) (w : Workspace.t) (dt : Dependency_tree.t) : unit =
-    let w' = Workspace.(w / "dep_tree.json") in
+  let main (abs : bool) (w : Workspace.t) (dt : Dependency_tree.t) : unit =
     Log.info "Dependency tree \"%a\" generated successfully." Fpath.pp dt.path;
     Log.verbose "%a" (Dependency_tree.pp abs) dt;
-    Workspace.output_noerr Side w' (Dependency_tree.pp abs) dt
-
-  let main (abs : bool) (w : Workspace.t) (dt : Dependency_tree.t) : unit =
     Workspace.log w "%a@." (Dependency_tree.pp abs) dt;
     match w.path with
     | Single _ -> Workspace.output_noerr Main w (Dependency_tree.pp abs) dt
+    | Bundle _ ->
+      let w' = Workspace.(w / "dep_tree.json") in
+      Workspace.output_noerr Side w' (Dependency_tree.pp abs) dt
     | _ -> ()
 end
 
 let run (env : Options.env) (w : Workspace.t) (input : Fpath.t) :
     Dependency_tree.t Exec.result =
   let* dt = Graphjs.dep_tree env.multifile input in
-  Output.dep_tree env.absolute_dependency_paths w dt;
   Output.main env.absolute_dependency_paths w dt;
   Ok dt
 

--- a/src/client/cmd_parse.ml
+++ b/src/client/cmd_parse.ml
@@ -59,7 +59,7 @@ module Output = struct
 
   let main (w : Workspace.t) (prog : 'm Prog.t) : unit =
     let multifile = Prog.is_multifile prog in
-    Workspace.log w "%a@." (Prog.pp ~filename:multifile) prog
+    Workspace.log w "%a" (Prog.pp ~filename:multifile) prog
 end
 
 let normalizer_env (env : Options.env) (w : Workspace.t) : Normalizer.Env.t =

--- a/src/client/cmd_query.ml
+++ b/src/client/cmd_query.ml
@@ -30,7 +30,7 @@ module Output = struct
       (vulns : Vulnerability.Set.t) : unit =
     Log.info "Vulnerability queries ran successfully%a" pp_mrel mrel;
     Log.verbose "%a@." (Vulnerability.Set.pp path) vulns;
-    Workspace.log w "%a@." (Vulnerability.Set.pp path) vulns;
+    Workspace.log w "%a" (Vulnerability.Set.pp path) vulns;
     match (w.path, mrel) with
     | (Single _, _) ->
       Workspace.output_noerr Main w Vulnerability.Set.pp_json vulns
@@ -70,8 +70,9 @@ let bulk_interface (env : Options.env) : (module Bulk.CmdInterface) =
   end )
 
 let main (opts : Options.t) () : unit Exec.result =
+  let ext = Some "json" in
   let env = Options.{ mdg_env = validate_mdg_env opts.env.mdg_env } in
-  let w = Workspace.create ~default:`None opts.inputs opts.output in
+  let w = Workspace.create ~default:(`Single ext) opts.inputs opts.output in
   let* _ = Workspace.prepare w in
   let* inputs = Bulk.InputTree.generate opts.inputs in
   let module Interface = (val bulk_interface env) in

--- a/src/client/cmd_validate.ml
+++ b/src/client/cmd_validate.ml
@@ -1,0 +1,117 @@
+open Graphjs_base
+open Graphjs_query
+open Result
+
+module Options = struct
+  type env = { query_env : Cmd_query.Options.env }
+
+  type t =
+    { inputs : Fpath.t list
+    ; output : Fpath.t option
+    ; env : env
+    }
+
+  let env (query_env : Cmd_query.Options.env) : env = { query_env }
+
+  let cmd (inputs : Fpath.t list) (output : Fpath.t option) (env : env) : t =
+    { inputs; output; env }
+end
+
+module Parser = struct
+  let expected (input : Fpath.t) : Json.t Exec.result =
+    let fpath = Fpath.(input / "expected" / "detection.json") in
+    let* exists = Fs.exists fpath in
+    if exists then Ok (Json.from_file (Fpath.to_string fpath))
+    else Exec.error "Cannot find expected query results \"%a\"" Fpath.pp fpath
+
+  let extended (input : Fpath.t) : Json.t option Exec.result =
+    let warn_f fpath =
+      Log.warn "Cannot find extended query results \"%a\"" Fpath.pp fpath in
+    let fpath = Fpath.(input / "expected" / "detection_extended.json") in
+    let* exists = Fs.exists fpath in
+    if exists then Ok (Some (Json.from_file (Fpath.to_string fpath)))
+    else warn_f fpath |> fun () -> Ok None
+
+  let sources (input : Fpath.t) : Fpath.t list Exec.result =
+    let fpath = Fpath.(input / "src") in
+    let* sources = Exec.bos (Bos.OS.Dir.contents ~rel:true fpath) in
+    Ok (List.filter (Fpath.has_ext "js") sources)
+end
+
+module Output = struct
+  let detected (w : Workspace.t) (path : Fpath.t) (vulns : Vulnerability.Set.t)
+      : unit =
+    let w' = Workspace.(w / "query" / "detected.json") in
+    Workspace.mkdir_noerr Main w';
+    Cmd_query.Output.main Workspace.(side_perm (w / "query")) path None vulns
+
+  let expected (w : Workspace.t) (expected : Query_expected.t) : unit =
+    let w' = Workspace.(w / "query" / "expected.json") in
+    Log.info "Expected query results read successfully.";
+    Log.verbose "%a" Query_expected.pp expected;
+    Workspace.output_noerr Side w' Query_expected.pp expected
+
+  let main (w : Workspace.t) (path : Fpath.t)
+      (confirm : Query_expected.Confirmation.t) : unit =
+    Log.info "Package \"%a\" successfully validated." Fpath.pp path;
+    Log.verbose "%a" Query_expected.Confirmation.pp confirm;
+    Workspace.log w "%a" Query_expected.Confirmation.pp confirm;
+    match w.path with
+    | Single _ ->
+      Workspace.output_noerr Main w Query_expected.Confirmation.pp confirm
+    | Bundle _ ->
+      let w' = Workspace.(w / "query" / "confirmation.txt") in
+      Workspace.output_noerr Side w' Query_expected.Confirmation.pp confirm
+    | _ -> ()
+end
+
+let get_query_expected (input : Fpath.t) : Query_expected.t Exec.result =
+  let* expected = Parser.expected input in
+  let* extended = Parser.extended input in
+  Ok (Query_expected.parse expected extended)
+
+let run_queries (env : Cmd_query.Options.env) (w : Workspace.t) (input : Fpath.t)
+    : Vulnerability.Set.t Exec.result =
+  let* sources = Parser.sources input in
+  let vulns = Ok Vulnerability.Set.empty in
+  Fun.flip2 List.fold_left vulns sources (fun acc mrel ->
+      let* acc' = acc in
+      let input' = Fpath.(input / "src" // mrel) in
+      let* vulns = Cmd_query.run ~mrel env (Workspace.side_perm w) input' in
+      Ok (Vulnerability.Set.union vulns acc') )
+
+let run (env : Options.env) (w : Workspace.t) (input : Fpath.t) :
+    Query_expected.Confirmation.t Exec.result =
+  let* vulns = run_queries env.query_env w input in
+  Output.detected w input vulns;
+  let* expected = get_query_expected input in
+  Output.expected w expected;
+  let confirm = Query_expected.Confirmation.compute expected vulns in
+  Output.main w input confirm;
+  Ok confirm
+
+let outcome (res : Query_expected.Confirmation.t Exec.result) :
+    Bulk.Instance.outcome =
+  match res with
+  | Ok confirm ->
+    if confirm.tp == confirm.exp.tp then
+      if confirm.tfp == confirm.exp.tfp then Success else Partial
+    else Failure
+  | Error _ -> Anomaly
+
+let bulk_interface (env : Options.env) : (module Bulk.CmdInterface) =
+  ( module struct
+    type t = Query_expected.Confirmation.t
+
+    let cmd = Docs.QueryCmd.name
+    let run = run env
+    let outcome = outcome
+  end )
+
+let main (opts : Options.t) () : unit Exec.result =
+  let w = Workspace.create ~default:`Bundle opts.inputs opts.output in
+  let* _ = Workspace.prepare w in
+  let* inputs = Bulk.InputTree.generate opts.inputs in
+  let module Interface = (val bulk_interface opts.env) in
+  let module Executor = Bulk.Executor (Interface) in
+  Executor.execute w inputs

--- a/src/client/docs.ml
+++ b/src/client/docs.ml
@@ -12,6 +12,7 @@ module ExitCodes = struct
   let deptree = 1
   let parsejs = 2
   let export_mdg = 3
+  let validate = 4
 end
 
 module Exits = struct
@@ -33,6 +34,10 @@ module Exits = struct
   let mdg =
     let export = info ~doc:"on MDG export error" ExitCodes.export_mdg in
     [ export ]
+
+  let validate =
+    let validate = info ~doc:"on query validation error" ExitCodes.validate in
+    [ validate ]
 end
 
 module CommonOpts = struct
@@ -73,11 +78,23 @@ module FileOpts = struct
     let parser = Fs.Parser.valid_file in
     Arg.(required & pos 0 (some parser) None & info [] ~docv ~doc)
 
+  let input_files =
+    let docv = "FILE..." in
+    let doc = "Path to the input files." in
+    let parser = Fs.Parser.valid_file in
+    Arg.(non_empty & pos_all parser [] & info [] ~docv ~doc)
+
   let input_dir =
-    let docv = "FILE" in
+    let docv = "DIR" in
     let doc = "Path to the input directory." in
     let parser = Fs.Parser.valid_dir in
     Arg.(required & pos 0 (some parser) None & info [] ~docv ~doc)
+
+  let input_dirs =
+    let docv = "DIR..." in
+    let doc = "Path to the input directories." in
+    let parser = Fs.Parser.valid_dir in
+    Arg.(non_empty & pos_all parser [] & info [] ~docv ~doc)
 
   let input_path =
     let docv = "FILE|DIR" in
@@ -285,19 +302,38 @@ end
 
 module QueryCmd = struct
   let name = "query"
-  let doc = "Executes pre-defined queries on a Node.js package"
+  let doc = "Executes pre-defined vulnerability queries on a Node.js package"
   let sdocs = Manpage.s_common_options
 
   let description =
-    [| "Given a Node.js package, executes a set of built-in queries to detect \
-        vulnerabilities in the package. Example vulnerabilities include code \
-        and command injection, path traversal, and prototype pollution. Note \
-        that these queries require the graph to be constructed using the \
-        unfold option." |]
+    [| "Given a Node.js package, executes a set of built-in vulnerability \
+        queries on the package. Example vulnerabilities include code and \
+        command injection, path traversal, and prototype pollution. Note that \
+        these queries require the graph to be constructed using the unfold \
+        option." |]
 
   let man = [ `S Manpage.s_description; `P (Array.get description 0) ]
   let man_xrefs = []
   let exits = Exits.common @ Exits.dependencies @ Exits.parse @ Exits.mdg
+end
+
+module ValidateCmd = struct
+  let name = "validate"
+  let doc = "Validates the query results for a Node.js package"
+  let sdocs = Manpage.s_common_options
+
+  let description =
+    [| "Given a Node.js package, executes a set of built-in vulnerability \
+        queries on the package, and validates the obtained results. As input, \
+        this command expects a directory containing two subdirectories: \
+        'src/', which holds the code to be analyzed, and 'expected/', which \
+        contains the expected results." |]
+
+  let man = [ `S Manpage.s_description; `P (Array.get description 0) ]
+  let man_xrefs = []
+
+  let exits =
+    Exits.common @ Exits.dependencies @ Exits.parse @ Exits.mdg @ Exits.validate
 end
 
 module Application = struct

--- a/src/client/domain/query_expected.ml
+++ b/src/client/domain/query_expected.ml
@@ -1,0 +1,102 @@
+open Graphjs_base
+open Graphjs_share
+open Graphjs_query
+
+module Entry = struct
+  type t =
+    { kind : string
+    ; file : string
+    ; line : int
+    ; ext : bool
+    }
+
+  let ext (entry : t) : bool = entry.ext
+
+  let create (kind : string) (file : string) (line : int) (ext : bool) : t =
+    { kind; file; line; ext }
+
+  let of_vuln (vuln : Vulnerability.t) : t =
+    let kind = Sink_kind.str vuln.sink.kind in
+    let file = vuln.node.at.file in
+    let line = vuln.line in
+    create kind file line false
+
+  let equal (entry1 : t) (entry2 : t) : bool =
+    String.equal entry1.kind entry2.kind
+    && String.equal entry1.file entry2.file
+    && Int.equal entry1.line entry2.line
+
+  let pp (ppf : Fmt.t) (entry : t) : unit =
+    Fmt.fmt ppf "{@\n@[<v 2>  ";
+    Fmt.fmt ppf "\"vuln_type\": %S," entry.kind;
+    Fmt.fmt ppf "@\n\"sink_file\": %S," entry.file;
+    Fmt.fmt ppf "@\n\"sink_line\": %d," entry.line;
+    Fmt.fmt ppf "@\n\"extended\": %b@]" entry.ext;
+    Fmt.fmt ppf "@\n}"
+
+  let str (entry : t) : string = Fmt.str "%a" pp entry
+end
+
+type t = Entry.t list
+
+let pp (ppf : Fmt.t) (vulns : t) : unit =
+  Fmt.fmt ppf "[@\n@[<v 2>  %a@]@\n]" Fmt.(pp_lst !>"@\n" Entry.pp) vulns
+
+let parse_vuln_list (ext : bool) (expected : Json.t) (acc : t) : t =
+  let expected_vulns = Json.to_list expected in
+  Fun.flip2 List.fold_left acc expected_vulns (fun acc vuln ->
+      let kind = Json.member "vuln_type" vuln |> Json.to_string in
+      let file = Json.member "sink_file" vuln |> Json.to_string in
+      let line = Json.member "sink_lineno" vuln |> Json.to_string in
+      let line' = int_of_string line in
+      let vuln = Entry.create kind file line' ext in
+      vuln :: acc )
+
+let parse (expected : Json.t) (extended : Json.t option) : t =
+  let vulns = parse_vuln_list false expected [] in
+  Option.fold extended ~none:vulns ~some:(fun extended' ->
+      parse_vuln_list true extended' vulns )
+
+module Confirmation = struct
+  type expected =
+    { tp : int
+    ; tfp : int
+    }
+
+  type t =
+    { exp : expected
+    ; tp : int
+    ; fp : int
+    ; tfp : int
+    }
+
+  let default =
+    let exp = { tp = 0; tfp = 0 } in
+    let dflt = { exp; tp = 0; fp = 0; tfp = 0 } in
+    fun () -> dflt
+
+  let create (expected : Entry.t list) : t =
+    let tfp = List.length (List.filter Entry.ext expected) in
+    let tp = List.length expected - tfp in
+    { (default ()) with exp = { tp; tfp } }
+
+  let tp (confirm : t) : t = { confirm with tp = confirm.tp + 1 }
+  let fp (confirm : t) : t = { confirm with fp = confirm.fp + 1 }
+  let tfp (confirm : t) : t = { confirm with tfp = confirm.tfp + 1 }
+
+  let pp (ppf : Fmt.t) (confirm : t) : unit =
+    Fmt.fmt ppf "True Positives: %d@\n" confirm.tp;
+    Fmt.fmt ppf "False Positives: %d@\n" confirm.fp;
+    Fmt.fmt ppf "True False Positives: %d@\n" confirm.tfp
+
+  let str (confirm : t) : string = Fmt.str "%a" pp confirm
+
+  let compute (expected : Entry.t list) (vulns : Vulnerability.Set.t) : t =
+    let confirm = create expected in
+    Fun.flip2 Vulnerability.Set.fold vulns confirm (fun vuln confirm' ->
+        let vuln' = Entry.of_vuln vuln in
+        let matched = List.find_all (Entry.equal vuln') expected in
+        if List.is_empty matched then fp confirm'
+        else if List.exists Entry.ext matched then tfp confirm'
+        else tp confirm' )
+end

--- a/src/client/domain/query_expected.ml
+++ b/src/client/domain/query_expected.ml
@@ -57,7 +57,7 @@ let parse (expected : Json.t) (extended : Json.t option) : t =
   Option.fold extended ~none:vulns ~some:(fun extended' ->
       parse_vuln_list true extended' vulns )
 
-module Confirmation = struct
+module Validation = struct
   type expected =
     { tp : int
     ; tfp : int
@@ -80,23 +80,23 @@ module Confirmation = struct
     let tp = List.length expected - tfp in
     { (default ()) with exp = { tp; tfp } }
 
-  let tp (confirm : t) : t = { confirm with tp = confirm.tp + 1 }
-  let fp (confirm : t) : t = { confirm with fp = confirm.fp + 1 }
-  let tfp (confirm : t) : t = { confirm with tfp = confirm.tfp + 1 }
+  let tp (valid : t) : t = { valid with tp = valid.tp + 1 }
+  let fp (valid : t) : t = { valid with fp = valid.fp + 1 }
+  let tfp (valid : t) : t = { valid with tfp = valid.tfp + 1 }
 
-  let pp (ppf : Fmt.t) (confirm : t) : unit =
-    Fmt.fmt ppf "True Positives: %d@\n" confirm.tp;
-    Fmt.fmt ppf "False Positives: %d@\n" confirm.fp;
-    Fmt.fmt ppf "True False Positives: %d@\n" confirm.tfp
+  let pp (ppf : Fmt.t) (valid : t) : unit =
+    Fmt.fmt ppf "True Positives: %d@\n" valid.tp;
+    Fmt.fmt ppf "False Positives: %d@\n" valid.fp;
+    Fmt.fmt ppf "True False Positives: %d@\n" valid.tfp
 
-  let str (confirm : t) : string = Fmt.str "%a" pp confirm
+  let str (valid : t) : string = Fmt.str "%a" pp valid
 
-  let compute (expected : Entry.t list) (vulns : Vulnerability.Set.t) : t =
-    let confirm = create expected in
-    Fun.flip2 Vulnerability.Set.fold vulns confirm (fun vuln confirm' ->
+  let validate (expected : Entry.t list) (vulns : Vulnerability.Set.t) : t =
+    let valid = create expected in
+    Fun.flip2 Vulnerability.Set.fold vulns valid (fun vuln valid' ->
         let vuln' = Entry.of_vuln vuln in
         let matched = List.find_all (Entry.equal vuln') expected in
-        if List.is_empty matched then fp confirm'
-        else if List.exists Entry.ext matched then tfp confirm'
-        else tp confirm' )
+        if List.is_empty matched then fp valid'
+        else if List.exists Entry.ext matched then tfp valid'
+        else tp valid' )
 end

--- a/src/client/dune
+++ b/src/client/dune
@@ -7,12 +7,14 @@
   workspace
   bulk
   exec
+  query_expected
   enums
   docs
   cmd_dependencies
   cmd_parse
   cmd_mdg
-  cmd_query)
+  cmd_query
+  cmd_validate)
  (libraries
   graphjs_base
   graphjs_share

--- a/src/client/utils/fs.ml
+++ b/src/client/utils/fs.ml
@@ -7,9 +7,20 @@ module Parser = struct
     | `Error of string
     ]
 
-  let check (check_f : Fpath.t -> bool) (kind : string) (fpath : t) : conv =
-    if check_f fpath then `Ok fpath
+  let valid (valid_f : t -> bool) (kind : string) (fpath : t) : conv =
+    if valid_f fpath then `Ok fpath
     else `Error (Fmt.str "Path '%a' is not a valid %s." pp fpath kind)
+
+  let valid_file (fpath : t) : (bool, [< `Msg of string ]) Result.t =
+    if Fpath.is_file_path fpath then Bos.OS.File.exists fpath
+    else Error (`Msg (Fmt.str "Path '%a' is not a valid file." pp fpath))
+
+  let valid_dir (fpath : t) : (bool, [< `Msg of string ]) Result.t =
+    if Fpath.is_dir_path fpath then Bos.OS.Dir.exists fpath
+    else Error (`Msg (Fmt.str "Path '%a' is not a valid directory." pp fpath))
+
+  let valid_path (fpath : t) : (bool, [< `Msg of string ]) Result.t =
+    Bos.OS.Path.exists fpath
 
   let parse (parse_f : t -> (bool, [< `Msg of string ]) Result.t)
       (kind : string) (fpath : t) : conv =
@@ -21,12 +32,12 @@ module Parser = struct
   let fix_dir (fpath : t) : t =
     if Fpath.exists_ext fpath then fpath else Fpath.to_dir_path fpath
 
-  let file = Fun.(check is_file_path "filename" << v, pp)
-  let dir = Fun.(check is_dir_path "directory" << fix_dir << v, pp)
-  let fpath = Fun.(check (fun _ -> true) "path" << fix_dir << v, pp)
-  let valid_file = Fun.(parse Bos.OS.File.exists "File" << v, pp)
-  let valid_dir = Fun.(parse Bos.OS.Dir.exists "Directory" << fix_dir << v, pp)
-  let valid_fpath = Fun.(parse Bos.OS.Path.exists "Path" << fix_dir << v, pp)
+  let file = Fun.(valid is_file_path "filename" << v, pp)
+  let dir = Fun.(valid is_dir_path "directory" << fix_dir << v, pp)
+  let fpath = Fun.(valid (fun _ -> true) "path" << fix_dir << v, pp)
+  let valid_file = Fun.(parse valid_file "File" << v, pp)
+  let valid_dir = Fun.(parse valid_dir "Directory" << fix_dir << v, pp)
+  let valid_fpath = Fun.(parse valid_path "Path" << fix_dir << v, pp)
 end
 
 let handle_error ~(default : 'a) (f : t -> 'a Exec.result) (path : t) : 'a =
@@ -36,6 +47,10 @@ let handle_error ~(default : 'a) (f : t -> 'a Exec.result) (path : t) : 'a =
     Log.warn "Unable to output to \"%a\".@\n%a" pp path Exec.pp_err err;
     default
 
+let exists (path : t) : bool Exec.result =
+  if is_dir_path path then Exec.bos (Bos.OS.Dir.exists path)
+  else Exec.bos (Bos.OS.File.exists path)
+
 let mkdir (path : t) : unit Exec.result =
   let path' = if is_dir_path path then path else parent path in
   Result.map (fun _ -> ()) (Exec.bos (Bos.OS.Dir.create path'))
@@ -44,10 +59,6 @@ let delete ?(recurse : bool = false) (path : t) : unit Exec.result =
   if is_dir_path path then
     Result.map (fun _ -> ()) (Exec.bos (Bos.OS.Dir.delete ~recurse path))
   else Result.map (fun _ -> ()) (Exec.bos (Bos.OS.File.delete path))
-
-let exists (path : t) : bool Exec.result =
-  if is_dir_path path then Exec.bos (Bos.OS.Dir.exists path)
-  else Exec.bos (Bos.OS.File.exists path)
 
 let copy (path : t) (src : t) : unit Exec.result =
   let open Result in
@@ -61,12 +72,11 @@ let write (path : t) (fmt : ('b, Fmt.t, unit, 'a) format4) : 'b =
   let write_f acc = Exec.bos (Bos.OS.File.writef path "%t" acc) in
   Fmt.kdly (fun acc -> write_f acc) fmt
 
+let exists_noerr (path : t) : bool = handle_error ~default:false exists path
 let mkdir_noerr (path : t) : unit = handle_error ~default:() mkdir path
 
 let delete_noerr ?(recurse : bool = false) (path : t) : unit =
   handle_error ~default:() (delete ~recurse) path
-
-let exists_noerr (path : t) : bool = handle_error ~default:false exists path
 
 let copy_noerr (path : t) (src : t) : unit =
   handle_error ~default:() (Fun.flip copy src) path

--- a/src/client/utils/workspace.ml
+++ b/src/client/utils/workspace.ml
@@ -85,11 +85,8 @@ let execute_noerr (p : perm) (w : t) (f : Fpath.t -> 'a) : unit =
 
 let log (w : t) (fmt : ('a, Fmt.t, unit, unit) format4) : 'a =
   match w.perm with
-  | Main when not Log.Config.(!log_verbose) -> Log.stdout fmt
+  | Main when not Log.Config.(!log_verbose) -> Log.stdout (fmt ^^ "@.")
   | _ -> Log.ignore fmt
-
-let print (w : t) (fmt : ('a, Fmt.t, unit, unit) format4) : 'a =
-  match w.perm with Main -> Log.stdout fmt | _ -> Log.ignore fmt
 
 let mkdir (p : perm) (w : t) : unit Exec.result = execute p w Fs.mkdir
 let mkdir_noerr (p : perm) (w : t) : unit = execute_noerr p w Fs.mkdir_noerr

--- a/src/client/utils/workspace.ml
+++ b/src/client/utils/workspace.ml
@@ -128,9 +128,9 @@ let clean (w : t) : unit Exec.result =
     Log.warn "Overriding \"%a\" file." Fpath.pp file_path;
     Fs.delete file_path in
   let error_dir dir_path =
-    Exec.error "Cannot override \"%a\" directory." Fpath.pp dir_path in
+    Exec.error "Cannot override the \"%a\" directory." Fpath.pp dir_path in
   let error_file file_path =
-    Exec.error "Cannot override \"%a\" file." Fpath.pp file_path in
+    Exec.error "Cannot override the \"%a\" file." Fpath.pp file_path in
   match w.path with
   | None -> Ok ()
   | (Single path | Bundle path) when not (Fpath.is_dir_path path) ->

--- a/src/graphjs.ml
+++ b/src/graphjs.ml
@@ -104,7 +104,23 @@ let query_cmd =
   let info = Cmd.info name ~doc ~sdocs ~man ~man_xrefs ~exits in
   Cmd.v info Term.(const Cmd_query.main $ query_opts $ copts)
 
-let cmd_list = [ dependencies_cmd; parse_cmd; mdg_cmd; query_cmd ]
+let validate_env =
+  let open Term in
+  const Cmd_validate.Options.env $ query_env
+
+let validate_opts =
+  let open Term in
+  const Cmd_validate.Options.cmd
+  $ Docs.FileOpts.input_dirs
+  $ Docs.FileOpts.output_dir
+  $ validate_env
+
+let validate_cmd =
+  let open Docs.ValidateCmd in
+  let info = Cmd.info name ~doc ~sdocs ~man ~man_xrefs ~exits in
+  Cmd.v info Term.(const Cmd_validate.main $ validate_opts $ copts)
+
+let cmd_list = [ dependencies_cmd; parse_cmd; mdg_cmd; query_cmd; validate_cmd ]
 
 let main_cmd =
   let open Docs.Application in

--- a/src/mdg/builder.ml
+++ b/src/mdg/builder.ml
@@ -693,7 +693,7 @@ and build_file (state : State.t) (file : 'm File.t) (main : bool)
   let state' = initialize_file state file main l_parent in
   let state'' = build_sequence state' file.body in
   Pcontext.file_built state''.pcontext file.path;
-  state''.env.cb_mdg file.mrel;
+  state''.env.cb_mdg_file file.mrel;
   state''
 
 module ExtendedMdg = struct

--- a/src/mdg/domain/state.ml
+++ b/src/mdg/domain/state.ml
@@ -13,7 +13,7 @@ module Env = struct
     { func_eval_mode : func_eval_mode
     ; run_cleaner_analysis : bool
     ; run_tainted_analysis : bool
-    ; cb_mdg : Fpath.t -> unit
+    ; cb_mdg_file : Fpath.t -> unit
     }
 
   let default =
@@ -21,7 +21,7 @@ module Env = struct
       { func_eval_mode = Opaque
       ; run_cleaner_analysis = true
       ; run_tainted_analysis = true
-      ; cb_mdg = (fun _ -> ())
+      ; cb_mdg_file = (fun _ -> ())
       } in
     fun () -> dflt
 end

--- a/src/query/domain/vulnerability.ml
+++ b/src/query/domain/vulnerability.ml
@@ -21,9 +21,10 @@ let compare (vuln1 : t) (vuln2 : t) : int = Node.compare vuln1.node vuln2.node
 
 let pp (ppf : Fmt.t) (vuln : t) : unit =
   Fmt.fmt ppf "{@\n@[<v 2>  ";
-  Fmt.fmt ppf "\"vuln_type\": \"%a\"" Sink_kind.pp vuln.sink.kind;
-  Fmt.fmt ppf "@\n\"sink\": %S" vuln.sink.name;
-  Fmt.fmt ppf "@\n\"sink_lineno\": %d@]" vuln.line;
+  Fmt.fmt ppf "\"vuln_type\": \"%a\"," Sink_kind.pp vuln.sink.kind;
+  Fmt.fmt ppf "@\n\"sink_file\": %S," vuln.node.at.file;
+  Fmt.fmt ppf "@\n\"sink_line\": %d," vuln.line;
+  Fmt.fmt ppf "@\n\"sink\": %S@]" vuln.sink.name;
   Fmt.fmt ppf "@\n}"
 
 let str (vuln : t) : string = Fmt.str "%a" pp vuln
@@ -35,8 +36,13 @@ module Set = struct
     let compare = compare
   end)
 
+  let pp_json (ppf : Fmt.t) (vulns : t) : unit =
+    Fmt.fmt ppf "[@\n@[<v 2>  %a@]@\n]" Fmt.(pp_iter iter !>"@\n" pp) vulns
+
+  let str_json (vulns : t) : string = Fmt.str "%a" pp_json vulns
+
   let pp (path : Fpath.t) (ppf : Fmt.t) (vulns : t) : unit =
-    if cardinal vulns > 0 then Fmt.(pp_iter iter !>"@\n" pp) ppf vulns
+    if cardinal vulns > 0 then pp_json ppf vulns
     else Fmt.fmt ppf "No vulnerabilities detected in \"%a\"." Fpath.pp path
 
   let str (path : Fpath.t) (vulns : t) : string = Fmt.str "%a" (pp path) vulns


### PR DESCRIPTION
This PR introduces a new command, `graphjs validate`, which validates the results of the `secbench` and `vulcan` datasets. THis command executes queries on each file in the dataset and compares the detected vulnerabilities against the expected results.