### PR TITLE
Prevent infinite cycle in exported analysis

### DIFF
--- a/src/client/cmd_mdg.ml
+++ b/src/client/cmd_mdg.ml
@@ -8,8 +8,9 @@ module Options = struct
   type env =
     { taint_config : Fpath.t
     ; func_eval_mode : Enums.FuncEvalMode.t
-    ; run_cleaner_analysis : bool
+    ; run_exported_analysis : bool
     ; run_tainted_analysis : bool
+    ; run_cleaner_analysis : bool
     ; export_graph : bool
     ; export_subgraphs : bool
     ; export_func_subgraphs : bool
@@ -31,15 +32,16 @@ module Options = struct
     | None -> Properties.default_taint_config ()
 
   let env (taint_config' : Fpath.t option)
-      (func_eval_mode' : Enums.FuncEvalMode.t) (no_cleaner_analysis : bool)
-      (no_tainted_analysis : bool) (no_export : bool) (no_subgraphs : bool)
-      (no_func_subgraphs : bool) (no_file_subgraphs : bool)
-      (export_view' : Export_view.t) (export_timeout' : int)
-      (parse_env' : Cmd_parse.Options.env) : env =
+      (func_eval_mode' : Enums.FuncEvalMode.t) (no_exported_analysis : bool)
+      (no_tainted_analysis : bool) (no_cleaner_analysis : bool)
+      (no_export : bool) (no_subgraphs : bool) (no_func_subgraphs : bool)
+      (no_file_subgraphs : bool) (export_view' : Export_view.t)
+      (export_timeout' : int) (parse_env' : Cmd_parse.Options.env) : env =
     { taint_config = parse_taint_config taint_config'
     ; func_eval_mode = func_eval_mode'
+    ; run_exported_analysis = not no_exported_analysis
+    ; run_tainted_analysis = not (no_exported_analysis || no_tainted_analysis)
     ; run_cleaner_analysis = not no_cleaner_analysis
-    ; run_tainted_analysis = not no_tainted_analysis
     ; export_graph = not no_export
     ; export_subgraphs = not no_subgraphs
     ; export_func_subgraphs = not no_func_subgraphs
@@ -126,8 +128,9 @@ end
 
 let builder_env (env : Options.env) : State.Env.t =
   { func_eval_mode = env.func_eval_mode
-  ; run_cleaner_analysis = env.run_cleaner_analysis
+  ; run_exported_analysis = env.run_exported_analysis
   ; run_tainted_analysis = env.run_tainted_analysis
+  ; run_cleaner_analysis = env.run_cleaner_analysis
   ; cb_mdg_file = Output.mdg_file
   }
 

--- a/src/client/cmd_validate.ml
+++ b/src/client/cmd_validate.ml
@@ -68,7 +68,7 @@ end
 let get_query_expected (input : Fpath.t) : Query_expected.t Exec.result =
   let* expected = Parser.expected input in
   let* extended = Parser.extended input in
-  Ok (Query_expected.parse expected extended)
+  Query_expected.parse expected extended
 
 let run_queries (env : Cmd_query.Options.env) (w : Workspace.t) (input : Fpath.t)
     : Vulnerability.Set.t Exec.result =

--- a/src/client/docs.ml
+++ b/src/client/docs.ml
@@ -234,17 +234,25 @@ module MdgOpts = struct
     let parse_f = Enums.FuncEvalMode.parse in
     Arg.(value & opt parse_f Opaque & info [ "eval-func" ] ~doc)
 
+  let no_exported_analysis =
+    let doc =
+      "Run without the exported analysis. This analysis determines calculates \
+       the nodes that are exported by the module and, therefore, controlled by \
+       an attacker. Running without this analysis will prevent the tainted \
+       analysis to be executed." in
+    Arg.(value & flag & info [ "no-exported-analysis" ] ~doc)
+
+  let no_tainted_analysis =
+    let doc =
+      "Run without the tainted analysis. This analysis marks exported nodes as \
+       tainted by adding a dependency edge to the Tainted Source node." in
+    Arg.(value & flag & info [ "no-tainted-analysis" ] ~doc)
+
   let no_cleaner_analysis =
     let doc =
       "Run without the cleaner analysis. This analysis removes unused nodes \
        from the graph, according to their type and purpose." in
     Arg.(value & flag & info [ "no-cleaner-analysis" ] ~doc)
-
-  let no_tainted_analysis =
-    let doc =
-      "Run without the tainted analysis. This analysis marks exported values \
-       as tainted sources." in
-    Arg.(value & flag & info [ "no-tainted-analysis" ] ~doc)
 
   let no_export =
     let doc = "Run without generating the .svg graph format." in

--- a/src/graphjs.ml
+++ b/src/graphjs.ml
@@ -66,8 +66,9 @@ let mdg_env =
   const Cmd_mdg.Options.env
   $ Docs.MdgOpts.taint_config
   $ Docs.MdgOpts.func_eval_mode
-  $ Docs.MdgOpts.no_cleaner_analysis
+  $ Docs.MdgOpts.no_exported_analysis
   $ Docs.MdgOpts.no_tainted_analysis
+  $ Docs.MdgOpts.no_cleaner_analysis
   $ Docs.MdgOpts.no_export
   $ Docs.MdgOpts.no_subgraphs
   $ Docs.MdgOpts.no_func_subgraphs

--- a/src/mdg/analyses/exported.ml
+++ b/src/mdg/analyses/exported.ml
@@ -126,6 +126,7 @@ let empty_exports (state : State.t) (ls_exported : Node.Set.t) : bool =
 let compute (env : Env.t) (state : State.t) : t =
   let exported = create () in
   let ls_exported = Jslib.exported_object state.mdg state.jslib in
+  Log.debug "ls_exported = %a" Node.Set.pp ls_exported;
   if not (empty_exports state ls_exported) then
     compute_object env state exported [] ls_exported;
   exported

--- a/src/mdg/domain/state.ml
+++ b/src/mdg/domain/state.ml
@@ -11,16 +11,18 @@ module Env = struct
 
   type t =
     { func_eval_mode : func_eval_mode
-    ; run_cleaner_analysis : bool
+    ; run_exported_analysis : bool
     ; run_tainted_analysis : bool
+    ; run_cleaner_analysis : bool
     ; cb_mdg_file : Fpath.t -> unit
     }
 
   let default =
     let dflt =
       { func_eval_mode = Opaque
-      ; run_cleaner_analysis = true
+      ; run_exported_analysis = true
       ; run_tainted_analysis = true
+      ; run_cleaner_analysis = true
       ; cb_mdg_file = (fun _ -> ())
       } in
     fun () -> dflt

--- a/src/mdg/graph/mdg.ml
+++ b/src/mdg/graph/mdg.ml
@@ -290,12 +290,14 @@ let object_nested_traversal ?(final = true)
     match nodes with
     | [] -> acc
     | (props, node) :: nodes' ->
-      let found = object_dynamic_traversal ~final f' mdg ls_visited node [] in
-      let found' = List.map (fun (p, n) -> (props @ [ p ], n)) found in
-      let (_, ls_found) = List.split found' in
+      let found =
+        object_dynamic_traversal ~final f' mdg ls_visited node []
+        |> List.map (fun (p, n) -> (props @ [ p ], n))
+        |> List.filter (fun (_, n) -> not (Node.Set.mem n ls_visited)) in
+      let (_, ls_found) = List.split found in
       let ls_visited' = Node.Set.union ls_visited (Node.Set.of_list ls_found) in
-      let nodes'' = nodes' @ found' in
-      let acc' = List.fold_right f found' acc in
+      let nodes'' = nodes' @ found in
+      let acc' = List.fold_right f found acc in
       traverse ls_visited' nodes'' acc' in
   traverse (Node.Set.singleton node) [ ([], node) ] (f ([], node) acc)
 


### PR DESCRIPTION
This PR addresses a bug that could lead to infinite execution during the analysis of exported nodes. Additionally, it introduces a new CLI flag `--no-exported-analysis`, allowing users to explicitly disable the exported nodes analysis when it's not required.