### PR TITLE
Fix the MDG construction for the dataset graphs

### DIFF
--- a/src/client/cmd_query.ml
+++ b/src/client/cmd_query.ml
@@ -58,7 +58,12 @@ let run ?(mrel : Fpath.t option) (env : Options.env) (w : Workspace.t)
   Ok vulns
 
 let outcome (res : Vulnerability.Set.t Exec.result) : Bulk.Instance.outcome =
-  match res with Ok _ -> Success | Error _ -> Anomaly
+  match res with
+  | Ok _ -> Success
+  | Error (`DepTree _) -> Failure
+  | Error (`ParseJS _) -> Failure
+  | Error (`ExportMDG _) -> Anomaly
+  | Error _ -> Anomaly
 
 let bulk_interface (env : Options.env) : (module Bulk.CmdInterface) =
   ( module struct

--- a/src/client/docs.ml
+++ b/src/client/docs.ml
@@ -279,10 +279,10 @@ module MdgOpts = struct
        include: (1) 'full' [default] for exporting the complete graph; (2) \
        'calls' for exporting the program's call graph; (3) 'object:<#loc>' for \
        exporting the graph of the object at location <#loc>; (4) \
-       'function:<#loc>' for exporting the graph of the function at location \
-       <#loc>; (5) 'reaches:<#loc>' for exporting the subgraph that reaches \
-       the node at location <#loc>; and (6) 'sinks' for exporting the subgraph \
-       that reaches every tainted sink of the program." in
+       'parent:<#loc>' for exporting the graph of the function/module at \
+       location <#loc>; (5) 'reaches:<#loc>' for exporting the subgraph that \
+       reaches the node at location <#loc>; and (6) 'sinks' for exporting the \
+       subgraph that reaches every tainted sink of the program." in
     let parse_f = Enums.ExportView.parse in
     Arg.(value & opt parse_f Full & info [ "export-view" ] ~doc)
 

--- a/src/client/enums.ml
+++ b/src/client/enums.ml
@@ -74,7 +74,7 @@ module ExportView = struct
     | Full -> Fmt.pp_str ppf "full"
     | Calls -> Fmt.pp_str ppf "calls"
     | Object _ -> Fmt.pp_str ppf "object"
-    | Function _ -> Fmt.pp_str ppf "function"
+    | Parent _ -> Fmt.pp_str ppf "function"
     | Reaches _ -> Fmt.pp_str ppf "reaches"
     | Sinks -> Fmt.pp_str ppf "sinks"
 
@@ -89,8 +89,8 @@ module ExportView = struct
     | "sinks" -> `Ok Sinks
     | view' when conv_param_view view "object" ->
       `Ok (Object (int_of_string (Str.matched_group 1 view')))
-    | view' when conv_param_view view "function" ->
-      `Ok (Function (int_of_string (Str.matched_group 1 view')))
+    | view' when conv_param_view view "parent" ->
+      `Ok (Parent (int_of_string (Str.matched_group 1 view')))
     | view' when conv_param_view view "reaches" ->
       `Ok (Reaches (int_of_string (Str.matched_group 1 view')))
     | _ -> `Error "Invalid export-view argument."

--- a/src/mdg/builder.ml
+++ b/src/mdg/builder.ml
@@ -568,19 +568,20 @@ and build_exported_function (state : State.t) (l_func : Node.t) : State.t =
   | Some { floc; func; eval_store; _ } ->
     let store = Store.copy eval_store in
     let curr_floc = floc in
+    let curr_stack = l_func :: state.curr_stack in
     let curr_parent = Some l_func in
-    let state' = { state with store; curr_floc; curr_parent } in
+    let state' = { state with store; curr_floc; curr_stack; curr_parent } in
     let state'' = initialize_hoisted_functions state' func.body in
     let this_cid = newcid func.left in
-    let l_this = State.add_parameter_node state' this_cid "this" in
-    State.add_parameter_edge state' l_func l_this 0;
+    let l_this = State.add_parameter_node state'' this_cid "this" in
+    State.add_parameter_edge state'' l_func l_this 0;
     Store.replace state''.store "this" (Node.Set.singleton l_this);
     Fun.flip List.iteri func.params (fun idx param ->
         let idx' = idx + 1 in
         let param_cid = newcid param in
         let name = Identifier.name param in
-        let l_param = State.add_parameter_node state' param_cid name in
-        State.add_parameter_edge state' l_func l_param idx';
+        let l_param = State.add_parameter_node state'' param_cid name in
+        State.add_parameter_edge state'' l_func l_param idx';
         Store.replace state''.store name (Node.Set.singleton l_param) );
     build_sequence state'' func.body
 

--- a/src/mdg/domain/jslib.ml
+++ b/src/mdg/domain/jslib.ml
@@ -16,6 +16,13 @@ let find_template (jslib : t) (name : string) : Node.t =
 let find (mdg : Mdg.t) (jslib : t) (name : string) : Node.t =
   Mdg.get_node mdg (find_template jslib name).loc
 
+let pp (ppf : Fmt.t) (jslib : t) : unit =
+  let pp_item ppf (name, l_jslib) =
+    Fmt.fmt ppf "%s -> %a" name Node.pp l_jslib in
+  Fmt.(pp_htbl !>"@\n") pp_item ppf jslib
+
+let str (jslib : t) : string = Fmt.str "%a" pp jslib
+
 let add_tainted_sink (mdg : Mdg.t) (store : Store.t) (jslib : t)
     (make_generic_sink_f : 'a -> Taint.sink) (generic_sink : 'a) : unit =
   let sink = make_generic_sink_f generic_sink in
@@ -34,12 +41,11 @@ let initialize_module (mdg : Mdg.t) (store : Store.t) (jslib : t)
   let name = "module" in
   let name_jslib = resolve_name file "module" in
   let l_module = Node.create_object name l_parent (Region.default ()) in
-  let ls_module = Node.Set.singleton l_module in
   Hashtbl.replace jslib name_jslib l_module;
   Mdg.add_node mdg l_module;
   Fun.flip Option.iter l_parent (fun l_parent' ->
       Mdg.add_edge mdg (Edge.create l_parent' l_module Dependency) );
-  Store.replace store name ls_module
+  Store.replace store name (Node.Set.singleton l_module)
 
 let initialize_exports (mdg : Mdg.t) (store : Store.t) (jslib : t)
     (file : Fpath.t option) (l_parent : Node.t option) : unit =
@@ -47,13 +53,12 @@ let initialize_exports (mdg : Mdg.t) (store : Store.t) (jslib : t)
   let prop = Property.Static "exports" in
   let name_module = resolve_name file "module" in
   let name_jslib = resolve_name file "exports" in
-  let l_exports = Node.create_object name l_parent (Region.default ()) in
-  let ls_exports = Node.Set.singleton l_exports in
   let l_module = find mdg jslib name_module in
+  let l_exports = Node.create_object name l_parent (Region.default ()) in
   Hashtbl.replace jslib name_jslib l_exports;
   Mdg.add_node mdg l_exports;
   Mdg.add_edge mdg (Edge.create l_module l_exports (Property prop));
-  Store.replace store name ls_exports
+  Store.replace store name (Node.Set.singleton l_exports)
 
 let create (tconf : Taint_config.t) (mdg : Mdg.t) (store : Store.t) : t =
   let jslib = Hashtbl.create Config.(!dflt_htbl_sz) in
@@ -65,14 +70,9 @@ let initialize (mdg : Mdg.t) (store : Store.t) (jslib : t)
   initialize_module mdg store jslib file l_parent;
   initialize_exports mdg store jslib file l_parent
 
-let pp (ppf : Fmt.t) (jslib : t) : unit =
-  let pp_item ppf (name, l_jslib) =
-    Fmt.fmt ppf "%s -> %a" name Node.pp l_jslib in
-  Fmt.(pp_htbl !>"@\n") pp_item ppf jslib
-
-let str (jslib : t) : string = Fmt.str "%a" pp jslib
-
 let exported_object ?(mrel : Fpath.t option) (mdg : Mdg.t) (jslib : t) :
     Node.Set.t =
   let l_module = find mdg jslib (resolve_name mrel "module") in
-  Mdg.object_static_lookup mdg l_module "exports"
+  Node.Set.map_flat
+    (Fun.flip (Mdg.object_static_lookup mdg) "exports")
+    (Mdg.(object_tail_versions mdg) l_module)

--- a/src/mdg/domain/state.ml
+++ b/src/mdg/domain/state.ml
@@ -65,7 +65,7 @@ let create (env' : Env.t) (tconf : Taint_config.t) (prog : 'm Prog.t) : t =
 let initialize (state : t) (path : Fpath.t) (mrel : Fpath.t) (main : bool)
     (l_parent : Node.t option) : t =
   let file = if main then None else Some mrel in
-  let store' = Store.copy state.pcontext.initial_store in
+  let store' = Store.copy state.pcontext.init_store in
   Jslib.initialize state.mdg store' state.jslib file l_parent;
   { state with
     store = store'
@@ -76,15 +76,13 @@ let initialize (state : t) (path : Fpath.t) (mrel : Fpath.t) (main : bool)
   }
 
 let copy (state : t) : t =
-  let mdg = Mdg.copy state.mdg in
   let store = Store.copy state.store in
-  { state with mdg; store }
+  { state with store }
 
 let lub (state1 : t) (state2 : t) : t =
-  let mdg = Mdg.lub state1.mdg state2.mdg in
   let store = Store.lub state1.store state2.store in
   let curr_return = Node.Set.union state1.curr_return state2.curr_return in
-  { state1 with mdg; store; curr_return }
+  { state1 with store; curr_return }
 
 type cid = Allocator.cid
 

--- a/src/mdg/domain/store.ml
+++ b/src/mdg/domain/store.ml
@@ -6,35 +6,33 @@ let create () : t = Hashtbl.create Config.(!dflt_htbl_sz)
 let copy (store : t) : t = Hashtbl.copy store
 let equal (store1 : t) (store2 : t) = Hashtbl.equal Node.Set.equal store1 store2
 
-let find (store : t) (key : string) : Node.Set.t =
-  Option.value ~default:Node.Set.empty (Hashtbl.find_opt store key)
+let find (store : t) (name : string) : Node.Set.t =
+  Option.value ~default:Node.Set.empty (Hashtbl.find_opt store name)
 
-let replace (store : t) (key : string) (values : Node.Set.t) : unit =
-  Hashtbl.replace store key values
+let replace (store : t) (name : string) (ls_value : Node.Set.t) : unit =
+  Hashtbl.replace store name ls_value
 
 let pp (ppf : Fmt.t) (store : t) : unit =
-  let pp_bind ppf (key, values) =
-    Fmt.fmt ppf "%s -> %a" key Node.Set.pp values in
+  let pp_bind ppf (name, ls_value) =
+    Fmt.fmt ppf "%s -> %a" name Node.Set.pp ls_value in
   Fmt.(pp_htbl !>"@\n" pp_bind) ppf store
 
 let str (store : t) : string = Fmt.str "%a" pp store
 
 let strong_update (store : t) (l_old : Node.t) (l_new : Node.t) : unit =
-  let replace_f value = if Node.equal l_old value then l_new else value in
-  Fun.flip Hashtbl.iter store (fun key values ->
-      let values' = Node.Set.map replace_f values in
-      replace store key values' )
+  let replace_f l_value = if Node.equal l_old l_value then l_new else l_value in
+  Fun.flip Hashtbl.iter store (fun name ls_value ->
+      replace store name (Node.Set.map replace_f ls_value) )
 
 let weak_update (store : t) (l_old : Node.t) (ls_new : Node.Set.t) : unit =
-  let replace_f value acc =
-    if Node.equal l_old value then Node.Set.union ls_new acc
-    else Node.Set.add value acc in
-  Fun.flip Hashtbl.iter store (fun key values ->
-      let values' = Node.Set.fold replace_f values Node.Set.empty in
-      replace store key values' )
+  let replace_f l_value acc =
+    if Node.equal l_old l_value then Node.Set.union ls_new acc
+    else Node.Set.add l_value acc in
+  Fun.flip Hashtbl.iter store (fun name ls_value ->
+      replace store name (Node.Set.fold replace_f ls_value Node.Set.empty) )
 
 let lub (store1 : t) (store2 : t) : t =
-  Fun.flip Hashtbl.iter store2 (fun key values2 ->
-      let values1 = find store1 key in
-      replace store1 key (Node.Set.union values1 values2) );
+  Fun.flip Hashtbl.iter store2 (fun name ls_value2 ->
+      let ls_value1 = find store1 name in
+      replace store1 name (Node.Set.union ls_value1 ls_value2) );
   store1

--- a/src/mdg/export/svg_exporter.ml
+++ b/src/mdg/export/svg_exporter.ml
@@ -159,7 +159,7 @@ let build_graph (env : Env.t) (mdg : Mdg.t) : Export_view.G.t =
   | Full -> Export_view.Full.build_graph mdg
   | Calls -> Export_view.Calls.build_graph mdg
   | Object loc -> Export_view.Object.build_graph mdg loc
-  | Function loc -> Export_view.Function.build_graph mdg loc
+  | Parent loc -> Export_view.Parent.build_graph mdg loc
   | Reaches loc -> Export_view.Reaches.build_graph mdg loc
   | Sinks -> Export_view.Sinks.build_graph mdg
 

--- a/src/query/query_engine.ml
+++ b/src/query/query_engine.ml
@@ -3,7 +3,7 @@ open Graphjs_mdg
 
 type t =
   { mdg : Mdg.t
-  ; tainted : Tainted.t
+  ; tainted : Node.Set.t
   }
 
 let initialize (e_mdg : Builder.ExtendedMdg.t) : t =

--- a/test/mdg_builder/exports.t/run.t
+++ b/test/mdg_builder/exports.t/run.t
@@ -23,9 +23,9 @@ Graph.js MDG Builder: simple exports
   this[#21] -
   x3[#22] -
   exports[#23] --< P(baz) >--> [[function]] $v3[#20]
-  [[taint]] --< D >--> exports[#8]
   [[taint]] --< D >--> [[function]] $v1[#9]
   [[taint]] --< D >--> [[function]] $v2[#13]
+  [[taint]] --< D >--> exports[#18]
 
 Graph.js MDG Builder: module exports
   $ graphjs mdg --no-export module.js
@@ -54,8 +54,8 @@ Graph.js MDG Builder: module exports
   this[#22] -
   x3[#23] -
   $v5[#24] --< P(baz) >--> [[function]] $v6[#21]
-  [[taint]] --< D >--> $v5[#19]
   [[taint]] --< D >--> [[function]] $v6[#21]
+  [[taint]] --< D >--> $v5[#24]
 
 Graph.js MDG Builder: dynamic exports
   $ graphjs mdg --no-export dynamic.js
@@ -87,11 +87,10 @@ Graph.js MDG Builder: dynamic exports
   export_prop[#24] --< D >--> module.*[#19]
   baz[#25] --< D >--> $v4[#26]
   $v4[#26] --< P(*) >--> [[function]] $v5[#21]
-  [[taint]] --< D >--> exports[#8]
   [[taint]] --< D >--> [[function]] $v1[#9]
   [[taint]] --< D >--> [[function]] $v3[#13]
-  [[taint]] --< D >--> module.*[#19]
   [[taint]] --< D >--> [[function]] $v5[#21]
+  [[taint]] --< D >--> $v4[#26]
 
 Graph.js MDG Builder: mixed exports
   $ graphjs mdg --no-export mixed.js
@@ -112,6 +111,6 @@ Graph.js MDG Builder: mixed exports
   y2[#16] -
   z2[#17] -
   exports[#18] --< P(bar) >--> [[function]] $v2[#13]
-  [[taint]] --< D >--> exports[#8]
   [[taint]] --< D >--> [[function]] $v1[#9]
   [[taint]] --< D >--> [[function]] $v2[#13]
+  [[taint]] --< D >--> exports[#18]

--- a/test/mdg_builder/flags.t/run.t
+++ b/test/mdg_builder/flags.t/run.t
@@ -15,9 +15,9 @@ Graph.js MDG Builder: tainted analysis flag
   $v3[#16] -
   $v2[#17] --< P(q) >--> $v3[#16]
   exports[#18] --< P(foo) >--> $v2[#17]
-  [[taint]] --< D >--> exports[#8]
   [[taint]] --< D >--> $v3[#16]
   [[taint]] --< D >--> $v2[#17]
+  [[taint]] --< D >--> exports[#18]
 
   $ graphjs mdg --no-export no_tainted_sources.js --no-tainted-analysis
   module[#7] --< P(exports) >--> exports[#8]

--- a/test/mdg_builder/require.t/run.t
+++ b/test/mdg_builder/require.t/run.t
@@ -81,7 +81,6 @@ Graph.js MDG Builder: multifile require
   exports[#32] --< P(bar1) >--> exports.bar1[#78]
   exports[#32] --< P(bar3) >--> exports.bar3[#83]
   exports[#32] --< P(bar4) >--> exports.bar4[#89]
-  exports[#32] --< Arg(0) >--> exports.bar4(...)[#91]
   "./baz"[#33] --< Arg(1) >--> require(...)[#34]
   require(...)[#34] --< Call >--> [[sink]] require[#3]
   require(...)[#34] --< D >--> baz[#35]
@@ -141,6 +140,7 @@ Graph.js MDG Builder: multifile require
   exports[#73] --< P(bar2) >--> bar2[#67]
   exports[#73] --< V(bar3) >--> exports[#74]
   exports[#74] --< P(bar3) >--> bar3[#71]
+  exports[#74] --< Arg(0) >--> exports.bar4(...)[#90]
   $v2.obj[#75] -
   $v2.foo(...)[#76] --< Call >--> [[function]] foo[#18]
   $v2.foo(...)[#76] --< D >--> $v11[#77]
@@ -159,7 +159,6 @@ Graph.js MDG Builder: multifile require
   $v9.q(...)[#87] --< D >--> $v16[#88]
   $v16[#88] -
   exports.bar4[#89] -
-  exports.bar4[#90] -
-  exports.bar4(...)[#91] --< Call >--> exports.bar4[#90]
-  exports.bar4(...)[#91] --< D >--> $v17[#92]
-  $v17[#92] -
+  exports.bar4(...)[#90] --< Call >--> exports.bar4[#89]
+  exports.bar4(...)[#90] --< D >--> $v17[#91]
+  $v17[#91] -


### PR DESCRIPTION
This PR addresses various issues within the MDG builder that were preventing the construction of 72 packages from the dataset. These fixes include:
- MDG object traversals
- Undeclared hoisted functions inside `if/while` blocks