### PR TITLE
Add basic callback argument unfolding mechanism

### DIFF
--- a/src/client/domain/query_expected.ml
+++ b/src/client/domain/query_expected.ml
@@ -39,7 +39,7 @@ end
 type t = Entry.t list
 
 let pp (ppf : Fmt.t) (vulns : t) : unit =
-  Fmt.fmt ppf "[@\n@[<v 2>  %a@]@\n]" Fmt.(pp_lst !>"@\n" Entry.pp) vulns
+  Fmt.fmt ppf "[@\n@[<v 2>  %a@]@\n]" Fmt.(pp_lst !>",@\n" Entry.pp) vulns
 
 let parse_vuln_list (ext : bool) (expected : Json.t) (acc : t) : t =
   let expected_vulns = Json.to_list expected in

--- a/src/query/domain/vulnerability.ml
+++ b/src/query/domain/vulnerability.ml
@@ -58,7 +58,7 @@ module Set = struct
   end)
 
   let pp_json (ppf : Fmt.t) (vulns : t) : unit =
-    Fmt.fmt ppf "[@\n@[<v 2>  %a@]@\n]" Fmt.(pp_iter iter !>"@\n" pp) vulns
+    Fmt.fmt ppf "[@\n@[<v 2>  %a@]@\n]" Fmt.(pp_iter iter !>",@\n" pp) vulns
 
   let str_json (vulns : t) : string = Fmt.str "%a" pp_json vulns
 


### PR DESCRIPTION
This PR enables the unfolding of functions that are passed as arguments to calls targeting unknown functions. This behaviour is necessary because tainted sinks are often located within these callback functions.