### PR TITLE
Force the usage of `Graphjs_base` in every library

### DIFF
--- a/src/ast/dune
+++ b/src/ast/dune
@@ -4,4 +4,6 @@
  (name graphjs_ast)
  (modules region metadata printer ast graphjs_ast)
  (private_modules metadata region printer)
- (libraries graphjs_base flow_parser))
+ (libraries graphjs_base flow_parser)
+ (flags
+  (:standard -open Graphjs_base)))

--- a/src/ast/graphjs_ast.ml
+++ b/src/ast/graphjs_ast.ml
@@ -1,5 +1,3 @@
-open Graphjs_base
-
 module Region = struct
   include Region
 end

--- a/src/ast/metadata.ml
+++ b/src/ast/metadata.ml
@@ -1,5 +1,3 @@
-open Graphjs_base
-
 open struct
   let id_gen = Generator.of_numbers ~init:1 ()
 end

--- a/src/ast/printer.ml
+++ b/src/ast/printer.ml
@@ -1,4 +1,3 @@
-open Graphjs_base
 open Ast
 
 module Config = struct

--- a/src/ast/region.ml
+++ b/src/ast/region.ml
@@ -1,5 +1,3 @@
-open Graphjs_base
-
 module Config = struct
   include Config
 

--- a/src/client/cmd_dependencies.ml
+++ b/src/client/cmd_dependencies.ml
@@ -1,4 +1,3 @@
-open Graphjs_base
 open Graphjs_parser
 open Result
 

--- a/src/client/cmd_mdg.ml
+++ b/src/client/cmd_mdg.ml
@@ -1,4 +1,3 @@
-open Graphjs_base
 open Graphjs_share
 open Graphjs_ast
 open Graphjs_mdg

--- a/src/client/cmd_parse.ml
+++ b/src/client/cmd_parse.ml
@@ -1,4 +1,3 @@
-open Graphjs_base
 open Graphjs_parser
 open Graphjs_ast
 open Result

--- a/src/client/cmd_query.ml
+++ b/src/client/cmd_query.ml
@@ -1,4 +1,3 @@
-open Graphjs_base
 open Graphjs_query
 open Result
 

--- a/src/client/cmd_validate.ml
+++ b/src/client/cmd_validate.ml
@@ -1,4 +1,3 @@
-open Graphjs_base
 open Graphjs_query
 open Result
 

--- a/src/client/domain/query_expected.ml
+++ b/src/client/domain/query_expected.ml
@@ -1,4 +1,3 @@
-open Graphjs_base
 open Graphjs_query
 
 module Entry = struct

--- a/src/client/domain/query_validation.ml
+++ b/src/client/domain/query_validation.ml
@@ -1,4 +1,3 @@
-open Graphjs_base
 open Graphjs_query
 module Expected = Query_expected.Entry
 

--- a/src/client/dune
+++ b/src/client/dune
@@ -24,4 +24,6 @@
   graphjs_mdg
   graphjs_query
   cmdliner
-  bos))
+  bos)
+ (flags
+  (:standard -open Graphjs_base)))

--- a/src/client/enums.ml
+++ b/src/client/enums.ml
@@ -1,5 +1,3 @@
-open Graphjs_base
-
 module DebugLvl = struct
   type t =
     | None

--- a/src/client/utils/bulk.ml
+++ b/src/client/utils/bulk.ml
@@ -1,5 +1,3 @@
-open Graphjs_base
-
 module Config = struct
   include Config
 

--- a/src/client/utils/exec.ml
+++ b/src/client/utils/exec.ml
@@ -1,5 +1,3 @@
-open Graphjs_base
-
 type error =
   [ `Generic of Fmt.t -> unit
   | `Failure of Fmt.t -> unit

--- a/src/client/utils/fs.ml
+++ b/src/client/utils/fs.ml
@@ -1,4 +1,3 @@
-open Graphjs_base
 open Fpath
 
 module Parser = struct

--- a/src/client/utils/workspace.ml
+++ b/src/client/utils/workspace.ml
@@ -1,5 +1,3 @@
-open Graphjs_base
-
 module Config = struct
   include Config
 

--- a/src/dune
+++ b/src/dune
@@ -9,4 +9,6 @@
   graphjs_ast
   graphjs_mdg
   graphjs_query
-  graphjs_client))
+  graphjs_client)
+ (flags
+  (:standard -open Graphjs_base)))

--- a/src/graphjs.ml
+++ b/src/graphjs.ml
@@ -1,4 +1,3 @@
-open Graphjs_base
 open Graphjs_client
 open Cmdliner
 

--- a/src/mdg/analyses/cleaner.ml
+++ b/src/mdg/analyses/cleaner.ml
@@ -1,5 +1,3 @@
-open Graphjs_base
-
 let is_excess_exports (mdg : Mdg.t) (l_exports : Node.t) : bool =
   let edges = Mdg.get_edges mdg l_exports.loc in
   let trans = Mdg.get_trans mdg l_exports.loc in

--- a/src/mdg/analyses/exported.ml
+++ b/src/mdg/analyses/exported.ml
@@ -1,5 +1,3 @@
-open Graphjs_base
-
 module Env = struct
   type cb_unfold_func = State.t -> Node.t -> State.t
 

--- a/src/mdg/analyses/tainted.ml
+++ b/src/mdg/analyses/tainted.ml
@@ -1,5 +1,3 @@
-open Graphjs_base
-
 let mark_tainted_exports (mdg : Mdg.t) (exported : Exported.t) : Node.t =
   let l_taint_source = Node.create_taint_source () in
   Mdg.add_node mdg l_taint_source;

--- a/src/mdg/builder.ml
+++ b/src/mdg/builder.ml
@@ -1,4 +1,3 @@
-open Graphjs_base
 open Graphjs_share
 open Graphjs_ast
 open Metadata

--- a/src/mdg/domain/allocator.ml
+++ b/src/mdg/domain/allocator.ml
@@ -1,4 +1,3 @@
-open Graphjs_base
 open Graphjs_ast
 
 type cid =

--- a/src/mdg/domain/jslib.ml
+++ b/src/mdg/domain/jslib.ml
@@ -1,4 +1,3 @@
-open Graphjs_base
 open Graphjs_share
 open Graphjs_ast
 

--- a/src/mdg/domain/npmlib.ml
+++ b/src/mdg/domain/npmlib.ml
@@ -1,4 +1,3 @@
-open Graphjs_base
 open Graphjs_share
 open Graphjs_ast
 

--- a/src/mdg/domain/pcontext.ml
+++ b/src/mdg/domain/pcontext.ml
@@ -1,4 +1,3 @@
-open Graphjs_base
 open Graphjs_ast
 
 module Floc = struct

--- a/src/mdg/domain/state.ml
+++ b/src/mdg/domain/state.ml
@@ -1,4 +1,3 @@
-open Graphjs_base
 open Graphjs_share
 open Graphjs_ast
 

--- a/src/mdg/domain/store.ml
+++ b/src/mdg/domain/store.ml
@@ -1,5 +1,3 @@
-open Graphjs_base
-
 type t = (string, Node.Set.t) Hashtbl.t
 
 let create () : t = Hashtbl.create Config.(!dflt_htbl_sz)

--- a/src/mdg/dune
+++ b/src/mdg/dune
@@ -24,4 +24,6 @@
   svg_exporter
   builder
   interceptor)
- (libraries graphjs_base graphjs_share graphjs_ast ocamlgraph))
+ (libraries graphjs_base graphjs_share graphjs_ast ocamlgraph)
+ (flags
+  (:standard -open Graphjs_base)))

--- a/src/mdg/export/export_view.ml
+++ b/src/mdg/export/export_view.ml
@@ -1,5 +1,3 @@
-open Graphjs_base
-
 exception Exn of (Fmt.t -> unit)
 
 let raise (fmt : ('b, Fmt.t, unit, 'a) format4) : 'b =

--- a/src/mdg/export/svg_exporter.ml
+++ b/src/mdg/export/svg_exporter.ml
@@ -1,5 +1,3 @@
-open Graphjs_base
-
 exception Exn of (Fmt.t -> unit)
 exception Timeout
 

--- a/src/mdg/graph/edge.ml
+++ b/src/mdg/graph/edge.ml
@@ -1,5 +1,3 @@
-open Graphjs_base
-
 type kind =
   | Dependency
   | Property of Property.t

--- a/src/mdg/graph/literal.ml
+++ b/src/mdg/graph/literal.ml
@@ -1,5 +1,3 @@
-open Graphjs_base
-
 type kind =
   | Null
   | String

--- a/src/mdg/graph/location.ml
+++ b/src/mdg/graph/location.ml
@@ -1,5 +1,3 @@
-open Graphjs_base
-
 open struct
   let loc_gen = Generator.of_numbers ~init:1 ()
 end

--- a/src/mdg/graph/mdg.ml
+++ b/src/mdg/graph/mdg.ml
@@ -1,5 +1,3 @@
-open Graphjs_base
-
 type t =
   { nodes : (Location.t, Node.t) Hashtbl.t
   ; edges : (Location.t, Edge.Set.t) Hashtbl.t

--- a/src/mdg/graph/node.ml
+++ b/src/mdg/graph/node.ml
@@ -1,4 +1,3 @@
-open Graphjs_base
 open Graphjs_ast
 
 type kind =

--- a/src/mdg/graph/property.ml
+++ b/src/mdg/graph/property.ml
@@ -1,5 +1,3 @@
-open Graphjs_base
-
 type t =
   | Static of string
   | Dynamic

--- a/src/mdg/graph/taint.ml
+++ b/src/mdg/graph/taint.ml
@@ -1,4 +1,3 @@
-open Graphjs_base
 open Graphjs_share
 
 type source =

--- a/src/mdg/interceptor.ml
+++ b/src/mdg/interceptor.ml
@@ -1,4 +1,3 @@
-open Graphjs_base
 open Graphjs_ast
 
 type cb_build_file =

--- a/src/parser/dependency_tree.ml
+++ b/src/parser/dependency_tree.ml
@@ -1,5 +1,3 @@
-open Graphjs_base
-
 exception Exn of (Fmt.t -> unit)
 
 let raise (fmt : ('b, Fmt.t, unit, 'a) format4) : 'b =

--- a/src/parser/dune
+++ b/src/parser/dune
@@ -3,4 +3,6 @@
 (library
  (name graphjs_parser)
  (modules dependency_tree flow_parser normalizer)
- (libraries graphjs_base graphjs_share graphjs_ast flow_parser))
+ (libraries graphjs_base graphjs_share graphjs_ast flow_parser)
+ (flags
+  (:standard -open Graphjs_base)))

--- a/src/parser/flow_parser.ml
+++ b/src/parser/flow_parser.ml
@@ -1,5 +1,3 @@
-open Graphjs_base
-
 exception Exn of (Fmt.t -> unit)
 
 module Config = struct

--- a/src/parser/normalizer.ml
+++ b/src/parser/normalizer.ml
@@ -1,4 +1,3 @@
-open Graphjs_base
 open Graphjs_ast
 open Graphjs_ast.Metadata
 module Flow = Flow_ast

--- a/src/query/builtin_queries.ml
+++ b/src/query/builtin_queries.ml
@@ -1,4 +1,3 @@
-open Graphjs_base
 open Graphjs_mdg
 
 module InjectionUnfold = struct

--- a/src/query/domain/vulnerability.ml
+++ b/src/query/domain/vulnerability.ml
@@ -1,4 +1,3 @@
-open Graphjs_base
 open Graphjs_mdg
 
 module Cwe = struct

--- a/src/query/dune
+++ b/src/query/dune
@@ -3,4 +3,6 @@
 (library
  (name graphjs_query)
  (modules vulnerability query_engine builtin_queries)
- (libraries graphjs_base graphjs_share graphjs_mdg))
+ (libraries graphjs_base graphjs_share graphjs_mdg)
+ (flags
+  (:standard -open Graphjs_base)))

--- a/src/query/query_engine.ml
+++ b/src/query/query_engine.ml
@@ -1,4 +1,3 @@
-open Graphjs_base
 open Graphjs_mdg
 
 type t =

--- a/src/share/dune
+++ b/src/share/dune
@@ -3,7 +3,9 @@
 (library
  (name graphjs_share)
  (modules site properties sink_kind taint_config)
- (libraries graphjs_base dune-site))
+ (libraries graphjs_base dune-site)
+ (flags
+  (:standard -open Graphjs_base)))
 
 (generate_sites_module
  (module site)

--- a/src/share/properties.ml
+++ b/src/share/properties.ml
@@ -1,5 +1,3 @@
-open Graphjs_base
-
 let search (locations : string list) (filename : string) : string option =
   Fun.flip List.find_map locations (fun dir ->
       let path = Filename.concat dir filename in

--- a/src/share/sink_kind.ml
+++ b/src/share/sink_kind.ml
@@ -1,5 +1,3 @@
-open Graphjs_base
-
 type t =
   | PathTraversal
   | CommandInjection

--- a/src/share/taint_config.ml
+++ b/src/share/taint_config.ml
@@ -1,5 +1,3 @@
-open Graphjs_base
-
 exception Exn of (Fmt.t -> unit)
 
 open struct


### PR DESCRIPTION
Add `open Graphjs_base` as a compilation flag to ensure we are always using the Graphjs_base library.