### PR TITLE
Clean the function evaluation mechanism

### DIFF
--- a/src/client/cmd_query.ml
+++ b/src/client/cmd_query.ml
@@ -6,8 +6,8 @@ module Options = struct
 
   let validate_env (env : env) : env =
     match env.mdg_env.func_eval_mode with
-    | Opaque ->
-      Log.warn "Unable to run built-in queries with 'opaque' function eval.";
+    | Connect ->
+      Log.warn "Unable to run built-in queries with 'connect' function eval.";
       Log.warn "Defaulting function evaluation mode to 'unfold:rec'...";
       { mdg_env = { env.mdg_env with func_eval_mode = UnfoldRec } }
     | _ -> env

--- a/src/client/docs.ml
+++ b/src/client/docs.ml
@@ -222,17 +222,18 @@ module MdgOpts = struct
 
   let func_eval_mode =
     let doc =
-      "Configures the evaluation of function calls during the MDG \
-       construction. Options include: (1) 'opaque' [default] for treating each \
-       function as a blackbox, creating a call edge from every call-site to \
-       the function's entry point; and (2) 'unfold' for opening each call-site \
-       by re-evaluating the function body. The unfold mode also accepts an \
-       optional modifier in the form unfold[:<mod>] to control how far to \
-       unfold: (1) [absent] for unfolding until the fixpoint is reached; (2) \
-       'unfold:rec' for unfolding until a recursive call is reached; (3) \
-       'unfold:<depth>' for unfolding until the maximum depth is reached." in
+      "Configures the mode for evaluating function calls during the MDG \
+       construction. Options include: (1) 'connect' [default] for treating \
+       each function as a blackbox, connecting with a call edge every \
+       call-site node to the called function's node; and (2) 'unfold' for \
+       opening each call-site by re-evaluating the function body. The unfold \
+       mode also accepts an optional modifier in the form unfold[:<mod>] to \
+       control how far to unfold: (1) [absent] for unfolding until the \
+       fixpoint is reached; (2) 'unfold:rec' for unfolding until a recursive \
+       call is reached; (3) 'unfold:<depth>' for unfolding until the maximum \
+       depth is reached." in
     let parse_f = Enums.FuncEvalMode.parse in
-    Arg.(value & opt parse_f Opaque & info [ "eval-func" ] ~doc)
+    Arg.(value & opt parse_f Connect & info [ "eval-func" ] ~doc)
 
   let no_exported_analysis =
     let doc =

--- a/src/client/enums.ml
+++ b/src/client/enums.ml
@@ -38,7 +38,7 @@ module FuncEvalMode = struct
 
   let pp (ppf : Fmt.t) (mode : t) : unit =
     match mode with
-    | Opaque -> Fmt.pp_str ppf "opaque"
+    | Connect -> Fmt.pp_str ppf "connect"
     | Unfold -> Fmt.pp_str ppf "unfold"
     | UnfoldRec -> Fmt.pp_str ppf "unfold:rec"
     | UnfoldDepth _ -> Fmt.pp_str ppf "unfold:<depth>"
@@ -49,7 +49,7 @@ module FuncEvalMode = struct
 
   let conv (mode : string) : conv =
     match mode with
-    | "opaque" -> `Ok Opaque
+    | "connect" -> `Ok Connect
     | "unfold" -> `Ok Unfold
     | "unfold:rec" -> `Ok UnfoldRec
     | mode' when conv_unfold_depth mode ->

--- a/src/mdg/analyses/tainted.ml
+++ b/src/mdg/analyses/tainted.ml
@@ -60,7 +60,7 @@ and mark_prop (state : State.t) (queue : queue) (edge : Edge.t)
 and mark_call (state : State.t) (queue : queue) (node : Node.t)
     (ls_tainted : Node.Set.t) : Node.Set.t =
   match state.env.func_eval_mode with
-  | Opaque -> ls_tainted
+  | Connect -> ls_tainted
   | Unfold | UnfoldRec | UnfoldDepth _ ->
     let l_retn = Mdg.get_return_of_call state.mdg node in
     let ls_tainted' = Node.Set.add node ls_tainted in

--- a/src/mdg/domain/state.ml
+++ b/src/mdg/domain/state.ml
@@ -3,7 +3,7 @@ open Graphjs_ast
 
 module Env = struct
   type func_eval_mode =
-    | Opaque
+    | Connect
     | Unfold
     | UnfoldRec
     | UnfoldDepth of int
@@ -19,7 +19,7 @@ module Env = struct
 
   let default =
     let dflt =
-      { func_eval_mode = Opaque
+      { func_eval_mode = Connect
       ; reset_locations = true
       ; run_exported_analysis = true
       ; run_tainted_analysis = true


### PR DESCRIPTION
The function evaluation mechanism (connect/unfold) was a bit messy and contained a bunch of duplicated code. This PR attempts to clean it as much as possible. Additionally, it renames the old `opaque` mode to `connect`.