### PR TITLE
Implement the prototype pollution query

### DIFF
--- a/config/jsmodel.jsonc
+++ b/config/jsmodel.jsonc
@@ -210,6 +210,8 @@
     { "type": "proto-policy", "name": "trimEnd", "source": "this", "targets": ["retn"] },
     { "type": "proto-policy", "name": "trimStart", "source": "this", "targets": ["retn"] },
     { "type": "proto-policy", "name": "valueOf", "source": "this", "targets": ["retn"] },
+    // Regex.prototype taint policies
+    { "type": "proto-policy", "name": "exec", "source": "arg1", "targets": ["retn"] },
     // Router taint policies
     { "type": "proto-policy", "name": "all", "source": "this", "targets": ["arg2"] },
     { "type": "proto-policy", "name": "get", "source": "this", "targets": ["arg2", "retn"] },

--- a/src/base/time.ml
+++ b/src/base/time.ml
@@ -35,3 +35,16 @@ let pp (ppf : Fmt.t) (time : t) : unit =
   Fmt.fmt ppf "%d.%03ds" ftime.secs ftime.ms
 
 let str (time : t) : string = Fmt.str "%a" pp time
+
+module Config = struct
+  include Config
+
+  let timeout = static Float.max_float
+end
+
+exception Timeout
+
+let timeout () : 'a = Stdlib.raise Timeout
+
+let timeout_check (time : t) : unit =
+  if finish time > Config.(!timeout) then timeout ()

--- a/src/client/cmd_validate.ml
+++ b/src/client/cmd_validate.ml
@@ -97,7 +97,7 @@ module Csv_exporter = struct
     match result with
     | Error _ -> Fmt.fmt ppf "-,-,-,-,-"
     | Ok valid ->
-      Fmt.fmt ppf "%d,%d,%d,%d,%d" valid.tp valid.tpe valid.tfp valid.e_tp
+      Fmt.fmt ppf "%d,%d,%d,%d,%d" valid.tp valid.tpe valid.fp valid.e_tp
         valid.e_tpe
 
   let pp_instance (ppf : Fmt.t) (instance : Query_validation.t Bulk.Instance.t)

--- a/src/client/docs.ml
+++ b/src/client/docs.ml
@@ -61,6 +61,14 @@ module CommonOpts = struct
     let docs = Manpage.s_common_options in
     Arg.(value & flag & info [ "v"; "verbose" ] ~doc ~docs)
 
+  let timeout =
+    let doc =
+      "Time (in seconds) allocated for the analysis of each file. This flag \
+       may not work exactly as expected due to the way timeouts are \
+       implemented in Graph.js." in
+    let docs = Manpage.s_common_options in
+    Arg.(value & opt float Float.max_float & info [ "timeout" ] ~doc ~docs)
+
   let override =
     let doc = "Override existing files when outputing to the provided path." in
     let docs = Manpage.s_common_options in

--- a/src/client/domain/query_validation.ml
+++ b/src/client/domain/query_validation.ml
@@ -4,13 +4,13 @@ module Expected = Query_expected.Entry
 type t =
   { tp : int
   ; tpe : int
-  ; tfp : int
+  ; fp : int
   ; e_tp : int
   ; e_tpe : int
   }
 
 let default =
-  let dflt = { tp = 0; tpe = 0; tfp = 0; e_tp = 0; e_tpe = 0 } in
+  let dflt = { tp = 0; tpe = 0; fp = 0; e_tp = 0; e_tpe = 0 } in
   fun () -> dflt
 
 let create (expected : Expected.t list) : t =
@@ -20,14 +20,14 @@ let create (expected : Expected.t list) : t =
 
 let tp (valid : t) : t = { valid with tp = valid.tp + 1 }
 let tpe (valid : t) : t = { valid with tpe = valid.tpe + 1 }
-let tfp (valid : t) : t = { valid with tfp = valid.tfp + 1 }
+let fp (valid : t) : t = { valid with fp = valid.fp + 1 }
 
 let pp (ppf : Fmt.t) (valid : t) : unit =
   Fmt.fmt ppf "True Positives: %d@\n" valid.tp;
   Fmt.fmt ppf "True Positives (Extended): %d@\n" valid.tpe;
   Fmt.fmt ppf "True Positives (All): %d@\n@\n" (valid.tp + valid.tpe);
-  Fmt.fmt ppf "False Positives (True): %d@\n" valid.tfp;
-  Fmt.fmt ppf "False Positives (All): %d@\n@\n" (valid.tpe + valid.tfp);
+  Fmt.fmt ppf "False Positives (True): %d@\n" valid.fp;
+  Fmt.fmt ppf "False Positives (All): %d@\n@\n" (valid.tpe + valid.fp);
   Fmt.fmt ppf "False Negatives: %d@\n" (max (valid.e_tp - valid.tp) 0);
   Fmt.fmt ppf "False Negatives (Extended): %d@\n"
     (max (valid.e_tpe - valid.tpe) 0);
@@ -41,6 +41,6 @@ let validate (expected : Expected.t list) (vulns : Vulnerability.Set.t) : t =
   Fun.flip2 Vulnerability.Set.fold vulns valid (fun vuln valid' ->
       let vuln' = Expected.of_vuln vuln in
       let matched = List.find_all (Expected.equal vuln') expected in
-      if List.is_empty matched then tfp valid'
+      if List.is_empty matched then fp valid'
       else if List.exists Expected.main matched then tp valid'
       else tpe valid' )

--- a/src/client/utils/exec.ml
+++ b/src/client/utils/exec.ml
@@ -32,8 +32,6 @@ let error (fmt : ('b, Fmt.t, unit, 'a result) format4) : 'b =
 let fail (fmt : ('b, Fmt.t, unit, 'a result) format4) : 'b =
   Fmt.kdly (fun acc -> exn (`Failure acc)) fmt
 
-let timeout () : 'b = exn `Timeout
-
 let bos (res : ('a, [< `Msg of string ]) Result.t) : 'a result =
   match res with
   | Ok _ as res' -> res'
@@ -41,12 +39,12 @@ let bos (res : ('a, [< `Msg of string ]) Result.t) : 'a result =
 
 let graphjs (exec_f : unit -> 'a) : 'a result =
   try Ok (exec_f ()) with
+  | Graphjs_base.Time.Timeout -> exn `Timeout
   | Graphjs_parser.Dependency_tree.Exn fmt -> exn (`DepTree fmt)
   | Graphjs_parser.Flow_parser.Exn fmt -> exn (`ParseJS fmt)
   | Graphjs_mdg.Jsmodel.Exn fmt -> exn (`Jsmodel fmt)
   | Graphjs_mdg.Export_view.Exn fmt -> exn (`ExportMDG fmt)
   | Graphjs_mdg.Svg_exporter.Exn fmt -> exn (`ExportMDG fmt)
-  | Graphjs_mdg.Svg_exporter.Timeout -> exn `Timeout
   | err ->
     let msg = Printexc.to_string err in
     let trace = Printexc.get_backtrace () in

--- a/src/graphjs.ml
+++ b/src/graphjs.ml
@@ -4,12 +4,13 @@ open Cmdliner
 type status = (unit Exec.result Cmd.eval_ok, Cmd.eval_error) Result.t
 
 let set_copts (colorless : bool) (lvl : Enums.DebugLvl.t) (verbose : bool)
-    (override' : bool) : unit =
+    (timeout' : Time.t) (override' : bool) : unit =
   Font.Config.(colored := not colorless);
   Log.Config.(log_warns := lvl >= Warn);
   Log.Config.(log_infos := verbose || lvl >= Info);
   Log.Config.(log_debugs := lvl >= All);
   Log.Config.(log_verbose := verbose);
+  Time.Config.(timeout := timeout');
   Workspace.Config.(override := override')
 
 let copts =
@@ -18,6 +19,7 @@ let copts =
   $ Docs.CommonOpts.colorless
   $ Docs.CommonOpts.debug
   $ Docs.CommonOpts.verbose
+  $ Docs.CommonOpts.timeout
   $ Docs.CommonOpts.override
 
 let dependencies_env =

--- a/src/mdg/builder.ml
+++ b/src/mdg/builder.ml
@@ -597,6 +597,7 @@ and build_export_decl (state : State.t) (specifier : 'm ExportDecl.specifier)
   | _ -> state
 
 and build_statement (state : State.t) (stmt : 'm Statement.t) : State.t =
+  Time.timeout_check state.curr_time;
   match stmt.el with
   | `ExprStmt _ -> state
   | `VarDecl left -> build_vardecl state (left @> stmt.md)
@@ -670,6 +671,7 @@ module ExtendedMdg = struct
     ; exported : Exported.t
     ; httpservers : Httpserver.t list
     ; tainted : Tainted.t
+    ; curr_time : Time.t
     }
 
   let compute_exported_analysis (state : State.t) : Exported.t =
@@ -694,8 +696,9 @@ module ExtendedMdg = struct
     let exported = compute_exported_analysis state in
     let httpservers = compute_httpserver state in
     let tainted = compute_tainted_analysis state jsmodel httpservers exported in
+    let curr_time = state.curr_time in
     compute_cleaner_analysis state;
-    { mdg; exported; httpservers; tainted }
+    { mdg; exported; httpservers; tainted; curr_time }
 end
 
 let reset_generators (env : State.Env.t) : unit =

--- a/src/mdg/domain/state.ml
+++ b/src/mdg/domain/state.ml
@@ -1,5 +1,7 @@
 open Graphjs_ast
 
+exception Timeout
+
 module Env = struct
   type t =
     { unfold_depth : int
@@ -38,6 +40,7 @@ type t =
   ; curr_stack : Node.t list
   ; curr_parent : Node.t option
   ; curr_return : Node.Set.t
+  ; curr_time : Time.t
   }
 
 and call_interceptor =
@@ -72,6 +75,7 @@ let create (env' : Env.t) (jsmodel : Jsmodel.t) (prog : 'm Prog.t) : t =
   ; curr_stack = []
   ; curr_parent = None
   ; curr_return = Node.Set.empty
+  ; curr_time = Time.start ()
   }
 
 let initialize (state : t) (path : Fpath.t) (mrel : Fpath.t) (main : bool)

--- a/src/mdg/export/svg_exporter.ml
+++ b/src/mdg/export/svg_exporter.ml
@@ -1,11 +1,8 @@
 exception Exn of (Fmt.t -> unit)
-exception Timeout
 
 let raise (fmt : ('b, Fmt.t, unit, 'a) format4) : 'b =
   let raise_f acc = raise (Exn acc) in
   Fmt.kdly (fun acc -> raise_f (fun ppf -> Log.fmt_error ppf "%t" acc)) fmt
-
-let timeout () : 'a = Stdlib.raise Timeout
 
 type graph_attrs = Graph.Graphviz.DotAttributes.graph list
 type vertex_attrs = Graph.Graphviz.DotAttributes.vertex list
@@ -197,7 +194,7 @@ let output_svg (env : Env.t) (svg : string) (dot : string) : unit =
   let cmd = svg_cmd env svg dot in
   match Sys.command cmd with
   | 0 -> ()
-  | 124 -> timeout ()
+  | 124 -> Time.timeout ()
   | _ -> raise "Unable to generate the %S file." svg
 
 let export_dot ?(env = Env.default ()) (dot : Fpath.t) (mdg : Mdg.t) : unit =

--- a/src/mdg/graph/mdg.ml
+++ b/src/mdg/graph/mdg.ml
@@ -85,7 +85,7 @@ let remove_edge (mdg : t) (edge : Edge.t) : unit =
 let remove_edges (mdg : t) (edges : Edge.t list) : unit =
   List.iter (remove_edge mdg) edges
 
-let get_dependencies (mdg : t) (node : Node.t) : Node.t list =
+let get_dependents (mdg : t) (node : Node.t) : Node.t list =
   get_edges mdg node.loc
   |> Edge.Set.filter Edge.is_dependency
   |> Edge.Set.map_list Edge.tar
@@ -112,6 +112,12 @@ let get_property_owner (mdg : t) (node : Node.t) : (Property.t * Node.t) list =
   get_trans mdg node.loc
   |> Edge.Set.filter Edge.is_property
   |> Edge.Set.map_list (fun edge -> (Edge.property edge, Edge.tar edge))
+
+let get_object_of_property (mdg : t) (node : Node.t) (prop : Property.t) :
+    Node.t list =
+  get_trans mdg node.loc
+  |> Edge.Set.filter (Edge.is_property ~prop)
+  |> Edge.Set.map_list Edge.tar
 
 let get_versions (mdg : t) (node : Node.t) : (Property.t * Node.t) list =
   get_edges mdg node.loc

--- a/src/mdg/graph/mdg.ml
+++ b/src/mdg/graph/mdg.ml
@@ -85,15 +85,20 @@ let remove_edge (mdg : t) (edge : Edge.t) : unit =
 let remove_edges (mdg : t) (edges : Edge.t list) : unit =
   List.iter (remove_edge mdg) edges
 
-let get_dependents (mdg : t) (node : Node.t) : Node.t list =
-  get_edges mdg node.loc
-  |> Edge.Set.filter Edge.is_dependency
-  |> Edge.Set.map_list Edge.tar
-
 let has_dependency (mdg : t) (node1 : Node.t) (node2 : Node.t) : bool =
   get_trans mdg node1.loc
   |> Edge.Set.filter Edge.is_dependency
   |> Edge.Set.exists (fun edge -> Node.equal edge.tar node2)
+
+let get_dependencies (mdg : t) (node : Node.t) : Node.t list =
+  get_trans mdg node.loc
+  |> Edge.Set.filter Edge.is_dependency
+  |> Edge.Set.map_list Edge.tar
+
+let get_dependents (mdg : t) (node : Node.t) : Node.t list =
+  get_edges mdg node.loc
+  |> Edge.Set.filter Edge.is_dependency
+  |> Edge.Set.map_list Edge.tar
 
 let has_property (mdg : t) (node : Node.t) (prop : Property.t) : bool =
   get_edges mdg node.loc |> Edge.Set.exists (Edge.is_property ~prop)

--- a/src/query/builtin_queries.ml
+++ b/src/query/builtin_queries.ml
@@ -14,32 +14,44 @@ module TaintedUnfold = struct
 end
 
 module PrototypeUnfold = struct
-  let find_polluted_updates (engine : Query_engine.t) : Node.Set.t =
-    let ls_update = Query_engine.dynamic_updates engine in
-    Fun.flip Node.Set.filter ls_update (fun l_update ->
-        let ls_dep = Mdg.get_dependents engine.mdg l_update in
-        if List.exists (Query_engine.is_tainted engine) ls_dep then
-          let ls_prop = Mdg.get_property engine.mdg l_update Dynamic in
-          List.exists (Query_engine.is_tainted engine) ls_prop
-        else false )
+  let find_polluted_lookups (engine : Query_engine.t) : Node.Set.t =
+    let ls_lookup = Query_engine.dynamic_lookups engine in
+    Fun.flip Node.Set.filter ls_lookup (fun l_lookup ->
+        let ls_dep = Mdg.get_dependencies engine.mdg l_lookup in
+        List.exists (Query_engine.is_tainted engine) ls_dep )
 
-  let find_polluted_lookup (engine : Query_engine.t) (l_update : Node.t) :
-      Node.Set.t =
-    let ls_orig = Mdg.object_orig_versions engine.mdg l_update in
-    Fun.flip Node.Set.filter ls_orig (fun l_orig ->
-        let ls_owner = Mdg.get_object_of_property engine.mdg l_orig Dynamic in
-        if not (List.is_empty ls_owner) then
-          let ls_dep = Mdg.get_dependents engine.mdg l_orig in
-          List.exists (Query_engine.is_tainted engine) ls_dep
-        else false )
+  let find_polluted_lookup_versions (engine : Query_engine.t)
+      (ls_lookup : Node.Set.t) : Node.Set.t =
+    Fun.flip2 Node.Set.fold ls_lookup Node.Set.empty (fun l_lookup acc ->
+        let ls_versions = Query_engine.object_versions engine l_lookup in
+        Node.Set.union ls_versions acc )
+
+  let is_polluted_update_value (engine : Query_engine.t) (l_update : Node.t)
+      (ls_props : Node.Set.t) : bool =
+    let mdg = engine.mdg in
+    let rec_f l_rec = Option.equal Node.equal (Some l_rec) l_update.parent in
+    let cs_f l_cs = Mdg.get_called_functions mdg l_cs |> Node.Set.of_list in
+    let ls_retn = Node.Set.filter Node.is_return ls_props in
+    let ls_cs = Node.Set.map (Mdg.get_call_of_return mdg) ls_retn in
+    let ls_rec = Node.Set.map_flat cs_f ls_cs in
+    not (Node.Set.exists rec_f ls_rec)
+
+  let has_polluted_update (engine : Query_engine.t) (l_update : Node.t) : bool =
+    let ls_dep = Mdg.get_dependencies engine.mdg l_update in
+    if List.exists (Query_engine.is_tainted engine) ls_dep then
+      let ls_props = Mdg.get_property engine.mdg l_update Dynamic in
+      if is_polluted_update_value engine l_update (Node.Set.of_list ls_props)
+      then List.exists (Query_engine.is_tainted engine) ls_props
+      else false
+    else false
 
   let run (engine : Query_engine.t) : Vulnerability.Set.t =
     let vulns = Vulnerability.Set.empty in
-    let ls_update = find_polluted_updates engine in
-    Fun.flip2 Node.Set.fold ls_update vulns (fun l_upd vulns ->
-        let ls_lookup = find_polluted_lookup engine l_upd in
-        if not (Node.Set.is_empty ls_lookup) then
-          let vuln = Vulnerability.pollution l_upd in
+    let ls_lookup = Query_engine.dynamic_lookups engine in
+    let ls_update = find_polluted_lookup_versions engine ls_lookup in
+    Fun.flip2 Node.Set.fold ls_update vulns (fun l_update vulns ->
+        if has_polluted_update engine l_update then
+          let vuln = Vulnerability.pollution l_update in
           Vulnerability.Set.add vuln vulns
         else vulns )
 end

--- a/src/query/builtin_queries.ml
+++ b/src/query/builtin_queries.ml
@@ -1,6 +1,6 @@
 open Graphjs_mdg
 
-module InjectionUnfold = struct
+module TaintedUnfold = struct
   let run (engine : Query_engine.t) : Vulnerability.Set.t =
     let vulns = Vulnerability.Set.empty in
     let l_sink_calls = Query_engine.tainted_sink_calls engine in
@@ -13,6 +13,38 @@ module InjectionUnfold = struct
         else vulns )
 end
 
+module PrototypeUnfold = struct
+  let find_polluted_updates (engine : Query_engine.t) : Node.Set.t =
+    let ls_update = Query_engine.dynamic_updates engine in
+    Fun.flip Node.Set.filter ls_update (fun l_update ->
+        let ls_dep = Mdg.get_dependents engine.mdg l_update in
+        if List.exists (Query_engine.is_tainted engine) ls_dep then
+          let ls_prop = Mdg.get_property engine.mdg l_update Dynamic in
+          List.exists (Query_engine.is_tainted engine) ls_prop
+        else false )
+
+  let find_polluted_lookup (engine : Query_engine.t) (l_update : Node.t) :
+      Node.Set.t =
+    let ls_orig = Mdg.object_orig_versions engine.mdg l_update in
+    Fun.flip Node.Set.filter ls_orig (fun l_orig ->
+        let ls_owner = Mdg.get_object_of_property engine.mdg l_orig Dynamic in
+        if not (List.is_empty ls_owner) then
+          let ls_dep = Mdg.get_dependents engine.mdg l_orig in
+          List.exists (Query_engine.is_tainted engine) ls_dep
+        else false )
+
+  let run (engine : Query_engine.t) : Vulnerability.Set.t =
+    let vulns = Vulnerability.Set.empty in
+    let ls_update = find_polluted_updates engine in
+    Fun.flip2 Node.Set.fold ls_update vulns (fun l_upd vulns ->
+        let ls_lookup = find_polluted_lookup engine l_upd in
+        if not (Node.Set.is_empty ls_lookup) then
+          let vuln = Vulnerability.pollution l_upd in
+          Vulnerability.Set.add vuln vulns
+        else vulns )
+end
+
 let run (engine : Query_engine.t) : Vulnerability.Set.t =
-  let injection_vulns = InjectionUnfold.run engine in
-  injection_vulns
+  let tainted_vulns = TaintedUnfold.run engine in
+  let prototype_vulns = PrototypeUnfold.run engine in
+  Vulnerability.Set.union tainted_vulns prototype_vulns

--- a/src/query/domain/vulnerability.ml
+++ b/src/query/domain/vulnerability.ml
@@ -5,7 +5,7 @@ module Cwe = struct
     | CWE22
     | CWE78
     | CWE94
-    | CWE471
+    | CWE1321
 
   let of_sink (sink : Taint.Sink.t) : t =
     match sink.kind with
@@ -18,7 +18,7 @@ module Cwe = struct
     | CWE22 -> Fmt.fmt ppf "CWE-22"
     | CWE78 -> Fmt.fmt ppf "CWE-78"
     | CWE94 -> Fmt.fmt ppf "CWE-94"
-    | CWE471 -> Fmt.fmt ppf "CWE-471"
+    | CWE1321 -> Fmt.fmt ppf "CWE-1321"
 
   let str (cwe : t) : string = Fmt.str "%a" pp cwe
 end
@@ -35,6 +35,9 @@ let create (cwe : Cwe.t) (node : Node.t) (file : string) (line : int) : t =
 
 let tainted (node : Node.t) (sink : Taint.Sink.t) : t =
   create (Cwe.of_sink sink) node node.at.file node.at.lpos.line
+
+let pollution (node : Node.t) : t =
+  create CWE1321 node node.at.file node.at.lpos.line
 
 let hash (vuln : t) : int = Node.hash vuln.node
 let equal (vuln1 : t) (vuln2 : t) : bool = Node.equal vuln1.node vuln2.node

--- a/src/query/query_engine.ml
+++ b/src/query/query_engine.ml
@@ -1,12 +1,15 @@
 open Graphjs_mdg
 
+exception Timeout
+
 type t =
   { mdg : Mdg.t
   ; tainted : Tainted.t
+  ; curr_time : Time.t
   }
 
 let initialize (e_mdg : Builder.ExtendedMdg.t) : t =
-  { mdg = e_mdg.mdg; tainted = e_mdg.tainted }
+  { mdg = e_mdg.mdg; tainted = e_mdg.tainted; curr_time = e_mdg.curr_time }
 
 let is_tainted (engine : t) (node : Node.t) : bool =
   Tainted.is_tainted engine.tainted node


### PR DESCRIPTION
This PR implement the prototype pollution query. This query still needs a lot of work to produce the required results. 
Additionally, it adds a new timeout mechanism to allow the analysis of the entire dataset.